### PR TITLE
Central location for test data

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -1,5 +1,6 @@
 // Base directory for test data
 def test_data_dir = "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data"
+def tol_test_data_dir = "https://tol-test-data.cog.sanger.ac.uk/data"
 
 params {
     test_data {
@@ -417,6 +418,62 @@ params {
                 test_merge_cool                               = "${test_data_dir}/genomics/homo_sapiens/cooler/merge/toy/toy.symm.upper.2.cool"
                 test_merge_cool_cp2                           = "${test_data_dir}/genomics/homo_sapiens/cooler/merge/toy/toy.symm.upper.2.cp2.cool"
 
+            }
+        }
+    }
+
+    tol_test_data {
+        'small_genome' {
+            'genomic_data' {
+                ont_fastq_gz                                   = "${tol_test_data_dir}/Anthocharis_cardamines/genomic_data/ilAntCard1/ont/ilAntCard1.ont.fastq.gz"
+                pacbio_bam                                     = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/pacbio/m64229e_210602_121910.ccs.bc1020_BAK8B_OA--bc1020_BAK8B_OA.bam"
+                pacbio_pbi                                     = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/pacbio/m64229e_210602_121910.ccs.bc1020_BAK8B_OA--bc1020_BAK8B_OA.bam.pbi"
+                hic_cram                                       = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/hic-arima2/40063_3#5.cram"
+                hic_crai                                       = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/hic-arima2/40063_3#5.cram.crai"
+                illumina_cram                                  = "${tol_test_data_dir}/Asterias_rubens/genomic_data/eAstRub1/illumina/27786_7#1.cram"
+                illumina_crai                                  = "${tol_test_data_dir}/Asterias_rubens/genomic_data/eAstRub1/illumina/27786_7#1.cram.crai"
+                tenx_i1_fastq_gz                               = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/10x/gfLaeSulp1_S41_L002_I1_001.fastq.gz"
+                tenx_r1_fastq_gz                               = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/10x/gfLaeSulp1_S41_L002_R1_001.fastq.gz"
+                tenx_r2_fastq_gz                               = "${tol_test_data_dir}/Laetiporus_sulphureus/genomic_data/gfLaeSulp1/10x/gfLaeSulp1_S41_L002_R2_001.fastq.gz"
+                tenx_subset_r1_fastq_gz                        = "${tol_test_data_dir}/Eimeria_tenella/genomic_data/pEimTen1/10x/subset/pEimTen1_S10_L007_R1_001.fastq.gz"
+                tenx_subset_r2_fastq_gz                        = "${tol_test_data_dir}/Eimeria_tenella/genomic_data/pEimTen1/10x/subset/pEimTen1_S10_L007_R2_001.fastq.gz"
+            }
+            'assembly' {
+                canu_contigs_fasta                             = "${tol_test_data_dir}/Eimeria_tenella/working/pEimTen1.canu.20190919/pEimTen1.contigs.fasta"
+                canu_contigs_longranger_mkref_targz            = "${tol_test_data_dir}/Eimeria_tenella/working/pEimTen1.canu.20190919/refdata-pEimTen1.contigs.tar.gz"
+            }
+        }
+        'medium_genome' {
+            'genomic_data' {
+                ont_fastq_gz                                   = "${tol_test_data_dir}/Pararge_aegeria/genomic_data/ilParAegt2/ont/ilParAege2.ont.fastq.gz"
+                pacbio_bam                                     = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/pacbio/m64016_200306_153933.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA.bam"
+                pacbio_pbi                                     = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/pacbio/m64016_200306_153933.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA.bam.pbi"
+                hic_cram                                       = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/hic-arima/34746_6#5.cram"
+                hic_crai                                       = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/hic-arima/34746_6#5.cram.crai"
+                hic_subset_aligned_1_bam                       = "${tol_test_data_dir}/Impatiens_glandulifera/genomic_data/dImpGla2/hic-dnazoo/subset_aligned/dImpGla2_SRR11908461.single_end_1.bam"
+                hic_subset_aligned_2_bam                       = "${tol_test_data_dir}/Impatiens_glandulifera/genomic_data/dImpGla2/hic-dnazoo/subset_aligned/dImpGla2_SRR11908461.single_end_2.bam"
+                illumina_cram                                  = "${tol_test_data_dir}/Erithacus_rubecula/genomic_data/bEriRub1/illumina/25350_5#2.cram"
+                illumina_crai                                  = "${tol_test_data_dir}/Erithacus_rubecula/genomic_data/bEriRub1/illumina/25350_5#2.cram.crai"
+                tenx_i1_fastq_gz                               = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/10x/ilEraDefo1_S1_L006_I1_001.fastq.gz"
+                tenx_r1_fastq_gz                               = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/10x/ilEraDefo1_S1_L006_R1_001.fastq.gz"
+                tenx_r2_fastq_gz                               = "${tol_test_data_dir}/Erannis_defoliaria/genomic_data/ilEraDefo1/10x/ilEraDefo1_S1_L006_R2_001.fastq.gz"
+            }
+            'assembly' {
+                hicanu_trimmed_reads_fasta_gz                  = "${tol_test_data_dir}/Diarsia_rubi/working/ilDiaRubi1.hicanu.20220110/subset/ilDiaRubi1.trimmedReads.fasta.gz"
+            }
+        }
+        'large_genome' {
+            'genomic_data' {
+                ont_fastq_gz                                   = "${tol_test_data_dir}/Sciurus_vulgaris/genomic_data/mSciVul1/ont/mSciVul1.ont.fastq.gz"
+                pacbio_bam                                     = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/pacbio/m64016_200911_163100.ccs.bc1020_BAK8B_OA--bc1020_BAK8B_OA.bam"
+                pacbio_pbi                                     = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/pacbio/m64016_200911_163100.ccs.bc1020_BAK8B_OA--bc1020_BAK8B_OA.bam.pbi"
+                hic_cram                                       = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/hic-arima2/35528_2#2.cram"
+                hic_crai                                       = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/hic-arima2/35528_2#2.cram.crai"
+                illumina_crai                                  = "${tol_test_data_dir}/Meles_meles/genomic_data/mMelMel1/illumina/31231_3#1.cram.crai"
+                illumina_cram                                  = "${tol_test_data_dir}/Meles_meles/genomic_data/mMelMel1/illumina/31231_3#1.cram"
+                tenx_i1_fastq_gz                               = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/10x/mCerEla1_S1_L006_I1_001.fastq.gz"
+                tenx_r1_fastq_gz                               = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/10x/mCerEla1_S1_L006_R1_001.fastq.gz"
+                tenx_r2_fastq_gz                               = "${tol_test_data_dir}/Cervus_elaphus/genomic_data/mCerEla1/10x/mCerEla1_S1_L006_R2_001.fastq.gz"
             }
         }
     }


### PR DESCRIPTION
- Currently only the config file. README to come later.
- Also, I wasn't sure key names could start with a digit (e.g. `10x_i1_fastq_gz`) so decided to spell it out `tenx_i1_fastq_gz`.
- Still need to decide the name of the S3 bucket (here I used `tol-test-data` as a placeholder)

The location on the farm is `/lustre/scratch123/tol/resources/nextflow/test_data`