### PR TITLE
Example configuration to run longranger via LSF

### DIFF
--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -10,7 +10,7 @@ process LONGRANGER_ALIGN {
     if (params.enable_conda) {
         exit 1, "Conda environments cannot be used when using longranger. Please use docker or singularity containers."
     }
-    if ( workflow.containerEngine == 'docker' ) {
+    if ( workflow.containerEngine != 'singularity' ) {
         exit 1, "Longranger is not configured to run in docker environment"
     }
     container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"

--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -10,6 +10,9 @@ process LONGRANGER_ALIGN {
     if (params.enable_conda) {
         exit 1, "Conda environments cannot be used when using longranger. Please use docker or singularity containers."
     }
+    if ( workflow.containerEngine == 'docker' ) {
+        exit 1, "Longranger is not configured to run in docker environment"
+    }
     container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"
 
     input:

--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -8,12 +8,13 @@ process LONGRANGER_ALIGN {
     def version = '2.2.2-c1'
 
     if (params.enable_conda) {
-        exit 1, "Conda environments cannot be used when using longranger. Please use docker or singularity containers."
+        exit 1, "Conda environments cannot be used when using longranger. Please use singularity."
     }
-    if ( workflow.containerEngine != 'singularity' ) {
-        exit 1, "The only container environment Longranger is configured for is docker"
+    if ( workflow.containerEngine == 'singularity' ) {
+        container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"
+    } else {
+        exit 1, "Longranger is only configured to run with singularity"
     }
-    container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"
 
     input:
     tuple val(meta), path(reference)

--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -11,7 +11,7 @@ process LONGRANGER_ALIGN {
         exit 1, "Conda environments cannot be used when using longranger. Please use docker or singularity containers."
     }
     if ( workflow.containerEngine != 'singularity' ) {
-        exit 1, "Longranger is not configured to run in docker environment"
+        exit 1, "The only container environment Longranger is configured for is docker"
     }
     container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"
 

--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -34,7 +34,7 @@ process LONGRANGER_ALIGN {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-    longranger: \$(echo \$(longranger mkref --version) | grep longranger | sed 's/.*(//' | sed 's/).*//')
+        longranger: \$(longranger align --version | grep longranger | sed 's/.*(//' | sed 's/).*//')
     END_VERSIONS
     """
 }

--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -2,13 +2,12 @@ process LONGRANGER_ALIGN {
     tag "$meta.id"
     label 'process_medium'
 
+    def version = '2.2.2-c1'
+
     if (params.enable_conda) {
-        exit 1, "Conda environments cannot be used when using longranger"
+        exit 1, "Conda environments cannot be used when using longranger. Please use docker or singularity containers."
     }
-    if ( workflow.containerEngine == 'singularity' || \
-            workflow.containerEngine == 'docker' ) {
-        exit 1, "Longranger can not be run in container environment"
-    }
+    container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"
 
     input:
     tuple val(meta), path(reference)

--- a/modules/longranger/align/main.nf
+++ b/modules/longranger/align/main.nf
@@ -1,4 +1,7 @@
 process LONGRANGER_ALIGN {
+    // To use in cluster mode, some extra configurations is needed.
+    // Visit tests/modules/longranger/align/nextflow.config for an example.
+
     tag "$meta.id"
     label 'process_medium'
 

--- a/modules/longranger/mkref/main.nf
+++ b/modules/longranger/mkref/main.nf
@@ -25,7 +25,7 @@ process LONGRANGER_MKREF {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        longranger: \$(echo \$(longranger mkref --version) | grep longranger | sed 's/.*(//' | sed 's/).*//')
+        longranger: \$(longranger mkref --version | grep longranger | sed 's/.*(//' | sed 's/).*//')
     END_VERSIONS
     """
 }

--- a/modules/longranger/mkref/main.nf
+++ b/modules/longranger/mkref/main.nf
@@ -25,7 +25,7 @@ process LONGRANGER_MKREF {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-    longranger: \$(echo \$(longranger mkref --version) | grep longranger | sed 's/.*(//' | sed 's/).*//')
+        longranger: \$(echo \$(longranger mkref --version) | grep longranger | sed 's/.*(//' | sed 's/).*//')
     END_VERSIONS
     """
 }

--- a/modules/longranger/mkref/main.nf
+++ b/modules/longranger/mkref/main.nf
@@ -2,13 +2,12 @@ process LONGRANGER_MKREF {
     tag "$meta.id"
     label 'process_medium'
 
+    def version = '2.2.2-c1'
+
     if (params.enable_conda) {
-        exit 1, "Conda environments cannot be used when using longranger"
+        exit 1, "Conda environments cannot be used when using longranger. Please use docker or singularity containers."
     }
-    if ( workflow.containerEngine == 'singularity' || \
-            workflow.containerEngine == 'docker' ) {
-        exit 1, "Longranger can not be run in container environment"
-    }
+    container "gitlab-registry.internal.sanger.ac.uk/tol-it/software/docker-images/longranger:${version}"
 
     input:
     tuple val(meta), path(reference)

--- a/tests/modules/longranger/align/main.nf
+++ b/tests/modules/longranger/align/main.nf
@@ -13,7 +13,7 @@ process DOWNLOAD_READS {
     for f in pEimTen1_S10_L007_R1_001.fastq.gz pEimTen1_S10_L007_R2_001.fastq.gz; do
         if [ ! -f  ${workDir}/10x/\$f ]
         then
-            wget -P ${workDir}/10x https://darwin.cog.sanger.ac.uk/longranger_nf_test/10x/\$f
+            wget -P ${workDir}/10x https://tolit.cog.sanger.ac.uk/test-data/Eimeria_tenella/genomic_data/pEimTen1/10x/subset/\$f
         fi
     done
     """
@@ -23,7 +23,7 @@ process DOWNLOAD_REF {
     script:
     """
     cd ${workDir}/
-    wget https://darwin.cog.sanger.ac.uk/longranger_nf_test/refdata-pEimTen1.contigs.tar.gz
+    wget https://tolit.cog.sanger.ac.uk/test-data/Eimeria_tenella/working/pEimTen1.canu.20190919/refdata-pEimTen1.contigs.tar.gz
     tar -xzvf refdata-pEimTen1.contigs.tar.gz
     """
 }

--- a/tests/modules/longranger/align/martian.lsf.template
+++ b/tests/modules/longranger/align/martian.lsf.template
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2016 10x Genomics, Inc. All rights reserved.
+# Copyright (c) 2022 Genome Research Ltd.
+#
+# =============================================================================
+# Setup Instructions
+# =============================================================================
+#
+# 1. Add any other necessary LSF arguments such as queue (-q) or account (-P).
+#    If your system requires a walltime (-W), 24 hours (24:00) is sufficient.
+#    We recommend you do not remove any arguments below or Martian may not run
+#    properly.
+#
+# 2. Change filename of lsf.template.example to lsf.template.
+#
+# =============================================================================
+# Template
+# =============================================================================
+#
+#BSUB -J __MRO_JOB_NAME__
+#BSUB -n __MRO_THREADS__
+#BSUB -o __MRO_STDOUT__
+#BSUB -e __MRO_STDERR__
+#BSUB -R "select[type==X86_64 && mem>__MRO_MEM_MB__] rusage[mem=__MRO_MEM_MB__]"
+#BSUB -R span[hosts=1]
+#BSUB -q long
+#BSUB -M __MRO_MEM_MB__
+
+singularity exec ${SINGULARITY_CONTAINER} env PATH="$PATH" \
+__MRO_CMD__

--- a/tests/modules/longranger/align/martian.lsf.template
+++ b/tests/modules/longranger/align/martian.lsf.template
@@ -7,12 +7,10 @@
 # Setup Instructions
 # =============================================================================
 #
-# 1. Add any other necessary LSF arguments such as queue (-q) or account (-P).
+#    Add any other necessary LSF arguments such as queue (-q) or account (-P).
 #    If your system requires a walltime (-W), 24 hours (24:00) is sufficient.
 #    We recommend you do not remove any arguments below or Martian may not run
 #    properly.
-#
-# 2. Change filename of lsf.template.example to lsf.template.
 #
 # =============================================================================
 # Template

--- a/tests/modules/longranger/align/nextflow.config
+++ b/tests/modules/longranger/align/nextflow.config
@@ -8,9 +8,10 @@ singularity {
     // Enter here the necessary configuration for the Singularity container
     // to see your HPC cluster. These options will have to be inserted in the
     // pipeline's configuration.
-    // Below is a working example for LSF at the Sanger institute: just change
-    // the path to martian.lsf.template (which you don't need to edit), and
+    // Below is a working example for LSF at the Sanger institute. The file
+    // named martian.lsf.template has to be shipped with the pipeline (update
+    // its relative path to the pipeline's root directory ${projectDir}), and
     // possibly change the path of the singularity binary.
     envWhitelist = "LSF_BINDIR,LSF_SERVERDIR,LSF_LIBDIR,LSF_ENVDIR"
-    runOptions = "-B /path/to/martian.lsf.template:/opt/longranger-2.2.2/martian-cs/2.3.2/jobmanagers/lsf.template -B /software -B /etc/lsf.conf --env APPEND_PATH=$LSF_BINDIR:$LSF_SERVERDIR:/software/singularity-v3.9.0/bin"
+    runOptions = "-B ${projectDir}/martian.lsf.template:/opt/longranger-2.2.2/martian-cs/2.3.2/jobmanagers/lsf.template -B /software -B /etc/lsf.conf --env APPEND_PATH=$LSF_BINDIR:$LSF_SERVERDIR:/software/singularity-v3.9.0/bin"
 }

--- a/tests/modules/longranger/align/nextflow.config
+++ b/tests/modules/longranger/align/nextflow.config
@@ -3,3 +3,14 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
     
 }
+
+singularity {
+    // Enter here the necessary configuration for the Singularity container
+    // to see your HPC cluster. These options will have to be inserted in the
+    // pipeline's configuration.
+    // Below is a working example for LSF at the Sanger institute: just change
+    // the path to martian.lsf.template (which you don't need to edit), and
+    // possibly change the path of the singularity binary.
+    envWhitelist = "LSF_BINDIR,LSF_SERVERDIR,LSF_LIBDIR,LSF_ENVDIR"
+    runOptions = "-B /path/to/martian.lsf.template:/opt/longranger-2.2.2/martian-cs/2.3.2/jobmanagers/lsf.template -B /software -B /etc/lsf.conf --env APPEND_PATH=$LSF_BINDIR:$LSF_SERVERDIR:/software/singularity-v3.9.0/bin"
+}

--- a/tests/modules/longranger/align/test.yml
+++ b/tests/modules/longranger/align/test.yml
@@ -5,9 +5,7 @@
     - longranger/align
   files:
     - path: output/longranger/pEimTen1/outs/possorted_bam.bam
-      md5sum: 741629ebd46fd019ef686d55d74ec0f7
     - path: output/longranger/pEimTen1/outs/possorted_bam.bam.bai
-      md5sum: 029fec0ac0c846b5a4e8935bcab4eae4
     - path: output/longranger/pEimTen1/outs/summary.csv
       md5sum: b91a17df2ef65e3015fa2a229bd72aee
     - path: output/longranger/versions.yml

--- a/tests/modules/longranger/align/test.yml
+++ b/tests/modules/longranger/align/test.yml
@@ -11,4 +11,4 @@
     - path: output/longranger/pEimTen1/outs/summary.csv
       md5sum: b91a17df2ef65e3015fa2a229bd72aee
     - path: output/longranger/versions.yml
-      md5sum: 9ace336820bfe317bcc7291a660b45c9
+      md5sum: 4fe9961ae727fd94c806f68b7a222855

--- a/tests/modules/longranger/mkref/main.nf
+++ b/tests/modules/longranger/mkref/main.nf
@@ -9,5 +9,5 @@ include { LONGRANGER_MKREF } from '../../../../modules/longranger/mkref/main.nf'
 
 workflow test_longranger_mkref {
     LONGRANGER_MKREF([ [id : "pEimTen1"],
-        file('https://darwin.cog.sanger.ac.uk/longranger_nf_test/pEimTen1.contigs.fasta', checkIfExists: true) ])
+        file('https://tolit.cog.sanger.ac.uk/test-data/Eimeria_tenella/working/pEimTen1.canu.20190919/pEimTen1.contigs.fasta', checkIfExists: true) ])
 }

--- a/tests/modules/longranger/mkref/test.yml
+++ b/tests/modules/longranger/mkref/test.yml
@@ -7,11 +7,11 @@
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa
       md5sum: ed4b0cdee98a0c86aa47382430d40708
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa.pac
-      md5sum: 5ec9e29d8541c85720058dcfdb7b9716
+      md5sum: 4d9fd2b014a6aaa3ba656a465ac117ca
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa.fai
       md5sum: fd079784ad008806e4568549240a3225
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa.ann
-      md5sum: 635f4758e786ea7c1a1c32d9e56ac4a6
+      md5sum: aecb798af9f443888f79a57098ec0389
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa.flat
       md5sum: 4d61d65371e2dee481b70a84c77b3381
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa.gdx
@@ -23,4 +23,4 @@
     - path: output/longranger/refdata-pEimTen1.contigs/fasta/genome.fa.amb
       md5sum: 204f3762875e5bf4002a2109763e4078
     - path: output/longranger/versions.yml
-      md5sum: 773ed3f19d93079168fa028a220b3bf9
+      md5sum: 61beb23583cf0e6ca04ef90d3b6d7a5c


### PR DESCRIPTION
This PR is to allow running Lonranger in LSF mode and on Singularity, without the need to install longranger beforehand.

Nextflow will use our container image from GitLab, and pass on the necessary Singularity options to enable LSF.
All it needs is a couple of extra options in the pipeline's configuration file.

I'm also fixing some minor things such as MD5 checksums, the command line to get the version, etc