### PR TITLE
Hi-C mapping fix

### DIFF
--- a/subworkflows/sanger-tol/hic_mapping/main.nf
+++ b/subworkflows/sanger-tol/hic_mapping/main.nf
@@ -133,9 +133,9 @@ workflow HIC_MAPPING {
         }
         | groupTuple()
         | map { key, bam -> [key.target, bam] } // Get meta back out of groupKey
-        | combine(ch_assemblies, by: 0)
-        | combine(SAMTOOLS_FAIDX.out.fai, by: 0)
-        | combine(SAMTOOLS_FAIDX.out.gzi.ifEmpty([[], []]), by: 0)
+        | join(ch_assemblies, by: 0)
+        | join(SAMTOOLS_FAIDX.out.fai, by: 0)
+        | join(SAMTOOLS_FAIDX.out.gzi, by: 0, remainder: true)
         | multiMap { meta, bams, assembly, fai, gzi ->
             bam:   [meta, bams]
             fasta: [meta, assembly]

--- a/subworkflows/sanger-tol/hic_mapping/main.nf
+++ b/subworkflows/sanger-tol/hic_mapping/main.nf
@@ -140,7 +140,7 @@ workflow HIC_MAPPING {
             bam:   [meta, bams]
             fasta: [meta, assembly]
             fai:   [meta, fai]
-            gzi:   [meta, gzi]
+            gzi:   gzi ? [meta, gzi] : [[], []] // need to pass an empty list - null doesn't work
         }
 
     //


### PR DESCRIPTION
Error when using non-gzipped assembly files that I missed - SAMTOOLS_MERGE didn't run as the gzi channel didn't `combine` correctly due to having no `meta` object.