### PR TITLE
Add yahs/makepairsfile module

### DIFF
--- a/modules/sanger-tol/yahs/makepairsfile/environment.yml
+++ b/modules/sanger-tol/yahs/makepairsfile/environment.yml
@@ -1,3 +1,5 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda

--- a/modules/sanger-tol/yahs/makepairsfile/environment.yml
+++ b/modules/sanger-tol/yahs/makepairsfile/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::samtools=1.22.1
+  - bioconda::yahs=1.2.2
+  - conda-forge::coreutils=9.5
+  - conda-forge::gawk=5.3.1

--- a/modules/sanger-tol/yahs/makepairsfile/main.nf
+++ b/modules/sanger-tol/yahs/makepairsfile/main.nf
@@ -1,0 +1,66 @@
+process YAHS_MAKEPAIRSFILE {
+    tag "${meta.id}"
+    label "process_low"
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/dd/ddcb4312a2df1f479502951d398f1bb983f82728446784f8fa9c4e91074ffdb7/data' :
+        'community.wave.seqera.io/library/samtools_yahs_coreutils_gawk:4f936f9704189766' }"
+
+    input:
+    tuple val(meta), path(scaffolds_fai), path(scaffolds_agp), path(contigs_fai), path(contigs_contacts)
+
+    output:
+    tuple val(meta), path("*.pairs.gz"), emit: pairs
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    gawk '
+        BEGIN {
+            OFS = "\t"
+            print "## pairs format v1.0"
+        }
+        { print "#chromsize:", \$1, \$2 }
+        END {
+            print "#columns:", "readID", "chr1", "pos1", "chr2", "pos2", "strand1", "strand2"
+        }' ${scaffolds_fai} > ${prefix}.pairs
+
+    juicer pre \\
+        ${contigs_contacts} \\
+        ${scaffolds_agp} \\
+        ${contigs_fai} |\\
+    gawk '
+        BEGIN { OFS = "\t" }
+        \$3 > 0 && \$7 > 0 {print ".", \$2, \$3, \$6, \$7, ".", "."}
+    ' |\\
+    LC_ALL=C sort -k2,2d -k4,4d -S50G >>\\
+    ${prefix}.pairs
+
+    bgzip -@${task.cpus} ${prefix}.pairs
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        juicer_pre: \$(juicer_pre --version)
+        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
+        sort: \$(sort --version | sed '1!d' | grep -o -E "[0-9]+(\\.[0-9]+)+")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.pairs.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        juicer_pre: \$(juicer_pre --version)
+        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
+        sort: \$(sort --version | sed '1!d' | grep -o -E "[0-9]+(\\.[0-9]+)+")
+    END_VERSIONS
+    """
+}

--- a/modules/sanger-tol/yahs/makepairsfile/meta.yml
+++ b/modules/sanger-tol/yahs/makepairsfile/meta.yml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "yahs_makepairsfile"
+description: |
+  Wrapper around the YaHS juicer_pre tool to create a valid sorted pairs file describing
+  Hi-C contacts among scaffolds using contacts among contigs and the YaHS AGP file describing
+  the makeup of scaffolds from those contigs.
+keywords:
+  - hic
+  - contact map
+  - pairs
+  - scaffolding
+tools:
+  - "yahs":
+      description: "YaHS, yet another Hi-C scaffolding tool."
+      homepage: "https://github.com/c-zhou/yahs"
+      documentation: "https://github.com/c-zhou/yahs"
+      tool_dev_url: "https://github.com/c-zhou/yahs"
+      doi: "10.1093/bioinformatics/btac808"
+      licence: ["MIT"]
+      identifier: biotools:yahs
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - scaffolds_fai:
+        type: file
+        description: |
+          samtools fasta index files describing the scaffolds to
+          make a pairs file for
+        pattern: "*.fai"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+    - scaffolds_agp:
+        type: file
+        description: |
+          AGP file describing the mapping of raw contigs to scaffolds
+        pattern: "*.agp"
+        ontologies:
+          - edam: "http://edamontology.org/format_3693" # AGP
+    - contigs_fai:
+        type: file
+        description: |
+          samtools fasta index files describing the scaffolds to
+          make a pairs file for
+        pattern: "*.fai"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+    - contigs_contacts:
+        type: file
+        description: |
+          Supported file format (BAM, BED, pairs, YaHS binary) describing Hi-C
+          contacts between contigs
+        pattern: "*.{bam,bed,bin,pa5}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_3003" # BED
+          - edam: "http://edamontology.org/format_3475" # TSV
+output:
+  pairs:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.pairs.gz":
+          type: file
+          description: |
+            Pairs file describing Hi-C contacts between scaffolds
+          pattern: "*.pairs.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: "http://edamontology.org/format_3750" # YAML
+authors:
+  - "@prototaxites"
+maintainers:
+  - "@prototaxites"

--- a/modules/sanger-tol/yahs/makepairsfile/tests/main.nf.test
+++ b/modules/sanger-tol/yahs/makepairsfile/tests/main.nf.test
@@ -1,0 +1,64 @@
+nextflow_process {
+
+    name "Test Process YAHS_MAKEPAIRSFILE"
+    script "../main.nf"
+    process "YAHS_MAKEPAIRSFILE"
+
+    tag "modules"
+    tag "modules_sangertol"
+    tag "yahs"
+    tag "yahs/makepairsfile"
+
+    test("Undibacterium unclassified - YaHS bin") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2_scaffolds_final.fa.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2_scaffolds_final.agp', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'baUndUnlc1.hic.hap2.p_ctg.fa.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2.bin', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success               },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("Undibacterium unclassified - YaHS bin - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2_scaffolds_final.fa.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2_scaffolds_final.agp', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'baUndUnlc1.hic.hap2.p_ctg.fa.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2.bin', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success               },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/sanger-tol/yahs/makepairsfile/tests/main.nf.test
+++ b/modules/sanger-tol/yahs/makepairsfile/tests/main.nf.test
@@ -17,9 +17,9 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2_scaffolds_final.fa.fai', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2_scaffolds_final.agp', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'baUndUnlc1.hic.hap2.p_ctg.fa.fai', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2.bin', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2_scaffolds_final.agp', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1.hic.hap2.p_ctg.fa.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2.bin', checkIfExists: true)
                 ]
                 """
             }
@@ -44,9 +44,9 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2_scaffolds_final.fa.fai', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2_scaffolds_final.agp', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'baUndUnlc1.hic.hap2.p_ctg.fa.fai', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'baUndUnlc1_hic_phased_hap2.bin', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2_scaffolds_final.agp', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1.hic.hap2.p_ctg.fa.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/analysis/scaffolding/baUndUnlc1_hic_phased_hap2.bin', checkIfExists: true)
                 ]
                 """
             }

--- a/modules/sanger-tol/yahs/makepairsfile/tests/main.nf.test.snap
+++ b/modules/sanger-tol/yahs/makepairsfile/tests/main.nf.test.snap
@@ -1,0 +1,68 @@
+{
+    "Undibacterium unclassified - YaHS bin": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pairs.gz:md5,c1be641ec6fb8cfd1b0fb674a12b51e5"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,a365bc19a25174bdf6a227418db2ac03"
+                ],
+                "pairs": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pairs.gz:md5,c1be641ec6fb8cfd1b0fb674a12b51e5"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,a365bc19a25174bdf6a227418db2ac03"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-28T16:06:08.417556224"
+    },
+    "Undibacterium unclassified - YaHS bin - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pairs.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,a365bc19a25174bdf6a227418db2ac03"
+                ],
+                "pairs": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pairs.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,a365bc19a25174bdf6a227418db2ac03"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-28T16:06:16.432728937"
+    }
+}


### PR DESCRIPTION
Adds a wrapper for the yahs `juicer_pre` tool that creates a valid sorted pairs file of Hi-C contacts for a set of scaffolds, using mapped contacts from a set of contigs and an AGP file describing the makeup of the scaffolds from the contigs.

This pairs file can be used in downstream tools such as PretextMap or Juicer to build contact maps.