### PR TITLE
Add genome statistics subworkflow

### DIFF
--- a/modules/sanger-tol/asmstats/environment.yml
+++ b/modules/sanger-tol/asmstats/environment.yml
@@ -1,7 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/nf-core-modules/refs/heads/main/modules/environment-schema.json
+---
 channels:
   - conda-forge
   - bioconda
-
 dependencies:
   - bioconda::seqtk=1.5
   - conda-forge::perl=5.32.1

--- a/modules/sanger-tol/asmstats/environment.yml
+++ b/modules/sanger-tol/asmstats/environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bioconda::seqtk=1.5
+  - conda-forge::perl=5.32.1

--- a/modules/sanger-tol/asmstats/main.nf
+++ b/modules/sanger-tol/asmstats/main.nf
@@ -1,0 +1,54 @@
+process ASMSTATS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c4/c47c4b4f55ce62f79edd9b4c5a26b7b1ed60684452dbbbd03f0be0d56c7b00be/data':
+        'community.wave.seqera.io/library/seqtk_perl:37201934bb74266e' }"
+
+    input:
+    tuple val(meta), path(assembly)
+
+    output:
+    tuple val(meta), path("*.stats"), emit: stats
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    // WARNING: This module includes the asmstats script as a module binary in
+    // ${moduleDir}/resources/usr/bin/asmstats. To use this module, you will
+    // either have to copy this file to ${projectDir}/bin or set the option
+    // nextflow.enable.moduleBinaries = true in your nextflow.config file.
+    def args    = task.ext.args ?: ''
+    def prefix  = task.ext.prefix ?: "${assembly.getName()}"
+    def VERSION = "1.0.0"
+    """
+    asmstats \\
+        $args \\
+        ${assembly} \\
+        > ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        asmstats: ${VERSION}
+        seqtk: \$(seqtk |& sed '/Version/!d; s/.* //')
+    END_VERSIONS
+    """
+
+    stub:
+    def args    = task.ext.args ?: ''
+    def prefix  = task.ext.prefix ?: "${meta.id}"
+    def VERSION = "1.0.0"
+    """
+    touch ${prefix}.stats
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        asmstats: \$(asmstats --version)
+        seqtk: \$(seqtk |& sed '/Version/!d; s/.* //')
+    END_VERSIONS
+    """
+}

--- a/modules/sanger-tol/asmstats/main.nf
+++ b/modules/sanger-tol/asmstats/main.nf
@@ -1,5 +1,5 @@
 process ASMSTATS {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/sanger-tol/asmstats/meta.yml
+++ b/modules/sanger-tol/asmstats/meta.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "asmstats"
+description: |
+  A tool to produce contig- and scaffold-level assembly statistics, including
+  composition, length, N50 and L50 metrics.
+keywords:
+  - assembly
+  - qc
+  - statistics
+tools:
+  - "asmstats":
+      description: |
+        A tool to produce contig- and scaffold-level assembly statistics, including
+        composition, length, N50 and L50 metrics.
+      homepage: "https://github.com/marcelauliano/Teaching/blob/main/asmstats"
+      documentation: "https://github.com/marcelauliano/Teaching/blob/main/asmstats"
+      tool_dev_url: "https://github.com/marcelauliano/Teaching/blob/main/asmstats"
+      licence: ["MIT"]
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - assembly:
+        type: file
+        description: Assembly fasta/gzipped fasta file
+        pattern: "*.{fa,fa.gz}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929" # FASTA
+output:
+  stats:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.stats":
+          type: file
+          description: Plain text file containing assembly statistics
+          pattern: "*.{stats}"
+          ontologies:
+            - edam: "http://edamontology.org/data_3671" # TEXT
+  versions:
+    - "versions.yml":
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: "http://edamontology.org/format_3750" # YAML
+authors:
+  - "@prototaxites"
+maintainers:
+  - "@prototaxites"

--- a/modules/sanger-tol/asmstats/resources/usr/bin/asmstats
+++ b/modules/sanger-tol/asmstats/resources/usr/bin/asmstats
@@ -1,0 +1,197 @@
+#!/usr/bin/env perl
+#
+#    Copyright (C) 2018-2019 Genome Research Ltd.
+#
+#    Author: Shane McCarthy <sm15@sanger.ac.uk>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+use strict;
+use warnings;
+use Carp;
+use Getopt::Long;
+
+my $opts = parse_params();
+stats($opts,'SCAFFOLD');
+
+# 'seqtk comp' output format:
+# 0        1       2       3       4       5       6       7       8   9       10  11  12
+# name     length  A       C       G       T       IUPAC2  IUPAC3  N   CpG     ts  tv  CpG-ts
+# Contig0  7097294 2186969 1367324 1358672 2183704 0       0       625 253444  0   0   0
+
+exit;
+
+#--------------------------------
+
+sub error
+{
+    my (@msg) = @_;
+    if ( scalar @msg ) { confess @msg; }
+    die
+        "About: Generate stats for fasta assembly file\n",
+        "Usage: asmstats [OPTIONS] <fasta|fastq>\n",
+        "Options:\n",
+        "   -g, --genome-size INT[kMG]  estimated genome size for NGX stats\n",
+        "       --seqtk <path>          path to seqtk executable [seqtk]\n",
+        "   -h, --help                  this help message.\n";
+}
+
+
+sub parse_params
+{
+    my $opts = { fa => '-', seqtk => 'seqtk', iter => 0 };
+    while (defined(my $arg=shift(@ARGV)))
+    {
+        if (                 $arg eq '--seqtk' ) { $$opts{seqtk} = shift(@ARGV); next; }
+        if ( $arg eq '-g' || $arg eq '--genome-size' ) { $$opts{genome_size} = shift(@ARGV); next; }
+        if ( $arg eq '-?' || $arg eq '-h' || $arg eq '--help' ) { error(); }
+        if (scalar @ARGV == 0) { $$opts{fa} = $arg; next; }
+        error("Unknown parameter \"$arg\". Run -h for help.\n");
+    }
+    error() if ($$opts{fa} eq '-' && $$opts{contigs} && $$opts{scaffolds});
+    unless ($$opts{fa} eq '-')
+    {
+        error(qq[$$opts{fa} does not exist]) unless (-s $$opts{fa});
+    }
+    if (exists $$opts{genome_size} && $$opts{genome_size} =~ m/(\d+)([kmgKMG])$/)
+    {
+        if (uc($2) eq 'K') { $$opts{genome_size} = $1 * 1e3; }
+        if (uc($2) eq 'M') { $$opts{genome_size} = $1 * 1e6; }
+        if (uc($2) eq 'G') { $$opts{genome_size} = $1 * 1e9; }
+    }
+    return $opts;
+}
+
+sub stats
+{
+    my ($opts,$type) = @_;
+
+    my @sums;
+    my %n50;
+
+    # transform input depending on type of sequence input and look at composition with 'seqtk comp'
+    my $input;
+    if ($type eq 'GAP')
+    {
+        # convert to a fasta file of just the N sequence
+        $input = qq[$$opts{seqtk} cutN -n1 -g $$opts{fa} | ] . q[awk '{print ">"NR; i = 0; while (i++ < $3-$2) { printf "N"; } print "\n"}' | ] . qq[$$opts{seqtk} comp - | ];
+    }
+    elsif ($type eq 'CONTIG')
+    {
+        # split sequence at any N to get contigs
+        $input = qq[$$opts{seqtk} cutN -n1 $$opts{fa} | $$opts{seqtk} comp - | ];
+    }
+    else
+    {
+        $input = qq[$$opts{seqtk} comp $$opts{fa} | ];
+    }
+
+    # read in 'seqtk comp' output
+    open(my $fh, "$input") or die("Could not open '$input' for reading");
+    while (my $line = <$fh>)
+    {
+        chomp $line;
+        my (@a) = split "\t", $line;
+        for (my $i=1; $i<scalar @a; $i++)
+        {
+            $sums[$i-1]+=$a[$i];
+        }
+        $n50{$a[0]}{len} = $a[1]; # scaffold length
+        $n50{$a[0]}{seq} = $a[1]-$a[8] if ($a[8]); # amount of non-N sequence in scaffold
+    }
+    close($fh) or die("Could not close '$input'");
+
+    my $n = scalar keys %n50;
+    my $sum = $sums[0];
+    my $ns = $sums[7];
+    my $sum50 = 0;
+    my $seqsum50 = 0;
+    my $vp = 0.5;
+    my $wp = 0.5;
+
+    # if there are no Ns, we'll only produce contig stats
+    $type = 'CONTIG' unless ($ns);
+
+    if ($n > 0)
+    {
+        my $result = $sum / $n;
+        my @keys = sort { $n50{$b}{len} <=> $n50{$a}{len} } keys %n50;
+        unless ($$opts{iter})
+        {
+            # use Data::Dumper;
+            # print Dumper(\@sums);
+            # on the first pass through, print fasta input path, composition, Ns (if any) and IUPAC related counts (if any)
+            print "$$opts{fa}\n";
+            printf(qq[A = $sums[1] (%.1f%%), C = $sums[2] (%.1f%%), G = $sums[3] (%.1f%%), T = $sums[4] (%.1f%%)], 100*$sums[1]/$sum, , 100*$sums[2]/$sum, 100*$sums[3]/$sum, 100*$sums[4]/$sum);
+            printf(qq[, N = $ns (%.1f%%)], 100*$ns/$sum) if ($ns);
+            printf(qq[, CpG = $sums[8] (%.1f%%)], 100*$sums[8]/$sum) if ($sums[8]);
+            print qq[, IUPAC3 = $sums[6], IUPAC2 = $sums[5], ts = $sums[9], tv = $sums[10], CpG-ts = $sums[11]] if ($sums[5] || $sums[6]);
+            print "\n";
+        }
+        print "$type\t" unless ($$opts{iter} == 0 && $type eq 'CONTIG');
+        print "sum = $sum, n = $n, ave = $result, largest = $n50{$keys[0]}{len}, smallest = $n50{$keys[-1]}{len}\n";
+        return if ($type eq 'GAP'); # no NX stats for GAP
+
+        my %res;
+        my $m = 0;
+        foreach my $key (@keys)
+        {
+            $sum50 += $n50{$key}{len};
+            $seqsum50 += $n50{$key}{seq} if ($n50{$key}{seq});
+            $m++;
+            if ( $sum50/$vp > $sum )
+            {
+                # print "$type\t" unless ($$opts{iter} == 0 && $type eq 'CONTIG');
+                # printf "N%.0f = $n50{$key}{len}, L%.0f = $m\n", $vp*100, $vp*100;
+                $res{100*$vp}{N} = $n50{$key}{len};
+                $res{100*$vp}{L} = $m;
+                # printf "$type\tN%.0f = $n50{$key}{len}, L%.0f = $m, T%.0f = $seqsum50 (%.1f%%\)\n", $vp*100, $vp*100, $vp*100, 100*$seqsum50/$sum;
+                $vp += .1;
+            }
+            if ( exists $$opts{genome_size} && $sum50/$wp > $$opts{genome_size} )
+            {
+                # print "$type\t" unless ($$opts{iter} == 0 && $type eq 'CONTIG');
+                # printf "NG%.0f = $n50{$key}{len}, LG%.0f = $m\n", $wp*100, $wp*100, $wp*100;
+                $res{100*$wp}{NG} = $n50{$key}{len};
+                $res{100*$wp}{LG} = $m;
+                # printf ", NG%.0f = $n50{$key}{len}, LG%.0f = $m, TG%.0f = $seqsum50 (%.1f%%\)\n", $wp*100, $wp*100, $wp*100, 100*$seqsum50/$$opts{genome_size};
+                $wp += .1;
+            }
+        }
+        if ($n > 1)
+        {
+            foreach my $val (50,60,70,80,90,100)
+            {
+                print "$type\t" unless ($$opts{iter} == 0 && $type eq 'CONTIG');
+                printf "N%.0f = %d, L%.0f = %d", $val, $res{$val}{N}, $val, $res{$val}{L};
+                if ($res{$val}{NG})
+                {
+                    printf ", NG%.0f = %d, LG%.0f = %d", $val, $res{$val}{NG}, $val, $res{$val}{LG};
+                }
+                print "\n";
+            }
+        }
+        $$opts{iter}++;
+        if ($ns && $type eq 'SCAFFOLD')
+        {
+            stats($opts,'CONTIG');
+            stats($opts,'GAP');
+        }
+    }
+}

--- a/modules/sanger-tol/asmstats/tests/main.nf.test
+++ b/modules/sanger-tol/asmstats/tests/main.nf.test
@@ -1,0 +1,59 @@
+nextflow_process {
+
+    name "Test Process ASMSTATS"
+    script "../main.nf"
+    process "ASMSTATS"
+
+    tag "modules"
+    tag "modules_sangertol"
+    tag "asmstats"
+
+    config "./nextflow.config"
+
+    test("meles meles - fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("meles meles - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/sanger-tol/asmstats/tests/main.nf.test.snap
+++ b/modules/sanger-tol/asmstats/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,66f87e4391d320f82e0b580bafb46935"
+                    "versions.yml:md5,e8d78f84b7fe3a16ef603a651edc2420"
                 ],
                 "stats": [
                     [
@@ -22,15 +22,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,66f87e4391d320f82e0b580bafb46935"
+                    "versions.yml:md5,e8d78f84b7fe3a16ef603a651edc2420"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-29T13:46:30.170536"
+        "timestamp": "2025-09-01T15:47:01.277673226"
     },
     "meles meles - fasta - stub": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,05166db6706453b214b205f0acc4d7a9"
+                    "versions.yml:md5,25c291e405becd2173f48a5130f5e03c"
                 ],
                 "stats": [
                     [
@@ -55,14 +55,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,05166db6706453b214b205f0acc4d7a9"
+                    "versions.yml:md5,25c291e405becd2173f48a5130f5e03c"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-29T13:45:12.765972"
+        "timestamp": "2025-09-01T15:47:06.899586868"
     }
 }

--- a/modules/sanger-tol/asmstats/tests/main.nf.test.snap
+++ b/modules/sanger-tol/asmstats/tests/main.nf.test.snap
@@ -1,0 +1,68 @@
+{
+    "meles meles - fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "GCA_922984935.2.subset.fasta.gz.stats:md5,4f692268fb5b50290af7454a32744055"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,66f87e4391d320f82e0b580bafb46935"
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "GCA_922984935.2.subset.fasta.gz.stats:md5,4f692268fb5b50290af7454a32744055"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,66f87e4391d320f82e0b580bafb46935"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-08-29T13:46:30.170536"
+    },
+    "meles meles - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,05166db6706453b214b205f0acc4d7a9"
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,05166db6706453b214b205f0acc4d7a9"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-08-29T13:45:12.765972"
+    }
+}

--- a/modules/sanger-tol/asmstats/tests/nextflow.config
+++ b/modules/sanger-tol/asmstats/tests/nextflow.config
@@ -1,0 +1,1 @@
+nextflow.enable.moduleBinaries = true

--- a/modules/sanger-tol/hiccramalign/bwamem2align/environment.yml
+++ b/modules/sanger-tol/hiccramalign/bwamem2align/environment.yml
@@ -1,7 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/nf-core-modules/refs/heads/main/modules/environment-schema.json
+---
 channels:
   - conda-forge
   - bioconda
-
 dependencies:
   - bioconda::bwa-mem2=2.2.1
   - bioconda::htslib=1.22.1

--- a/modules/sanger-tol/hiccramalign/minimap2align/environment.yml
+++ b/modules/sanger-tol/hiccramalign/minimap2align/environment.yml
@@ -1,7 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/nf-core-modules/refs/heads/main/modules/environment-schema.json
+---
 channels:
   - conda-forge
   - bioconda
-
 dependencies:
   - bioconda::htslib=1.22.1
   - bioconda::minimap2=2.30

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -93,7 +93,7 @@ workflow GENOME_STATISTICS {
             MERQURYFK_MERQURYFK.out.block_blob,
             MERQURYFK_MERQURYFK.out.hapmers_blob,
         )
-		| transpose()
+        | transpose()
 
     emit:
     asmstats             = ASMSTATS.out.stats

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -46,12 +46,18 @@ workflow GENOME_STATISTICS {
     ch_versions = ch_versions.mix(GFASTATS.out.versions)
 
     //
-    // Module: Assess assembly using BUSCO_BUSCO
+    // Module: Assess assembly using BUSCO_BUSCO. If val_busco_lineage
+    //         not provided then we properly skip the process entirely.
     //
+    ch_busco_lineage_input = Channel.empty()
+    if(val_busco_lineage) {
+        ch_busco_lineage_input = Channel.of(val_busco_lineage)
+    }
+
     BUSCO_BUSCO(
         ch_assemblies_split,               // assembly
         "genome",                          // busco mode
-        val_busco_lineage,                 // lineage to run BUSCO predictions
+        ch_busco_lineage_input,            // lineage to run BUSCO predictions
         val_busco_lineage_directory ?: [], // busco lineage directory
         [],                                // busco config
         true                               // clean intermediates

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -1,0 +1,101 @@
+include { ASMSTATS            } from '../../../modules/sanger-tol/asmstats/main'
+include { BUSCO_BUSCO         } from '../../../modules/nf-core/busco/busco/main'
+include { GFASTATS            } from '../../../modules/nf-core/gfastats/main'
+include { MERQURYFK_MERQURYFK } from '../../../modules/nf-core/merquryfk/merquryfk/main'
+
+workflow GENOME_STATISTICS {
+
+    take:
+    ch_assemblies               // channel: [ val(meta), asm1, asm2 ] - asm2 can be empty
+    ch_reads_fastk              // channel: [ val(meta), fastk_hist, [fastk ktabs] ]
+    ch_mat_fastk                // channel: [ val(meta), [fastk ktabs] ] - optional
+    ch_pat_fastk                // channel: [ val(meta), [fastk ktabs] ] - optional
+    val_busco_lineage           // string: busco lineage name
+    val_busco_lineage_directory // path: path to local busco lineages directory - optional
+
+    main:
+    ch_versions = Channel.empty()
+
+    ch_assemblies_split = ch_assemblies
+        | flatMap { meta, asm1, asm2 ->
+            def meta_asm1 = meta + [_hap: "hap1"]
+            def meta_asm2 = meta + [_hap: "hap2"]
+            [ [meta_asm1, asm1], [meta_asm2, asm2] ]
+        }
+        | filter { meta, asm -> asm }
+
+    //
+    // Module: Calculate assembly stats with asmstats
+    //
+    ASMSTATS(ch_assemblies_split)
+    ch_versions = ch_versions.mix(ASMSTATS.out.versions)
+
+    //
+    // Module: Calculate assembly stats with gfastats
+    //
+    GFASTATS(
+        ch_assemblies_split, // assembly
+        "fasta",             // out_fmt
+        [],                  // genome size
+        [],                  // target
+        [[],[]],             // agp file
+        [[],[]],             // include bed
+        [[],[]],             // exclude bed
+        [[],[]]              // instructions
+    )
+    ch_versions = ch_versions.mix(GFASTATS.out.versions)
+
+    //
+    // Module: Assess assembly using BUSCO_BUSCO
+    //
+    BUSCO_BUSCO(
+        ch_assemblies_split,               // assembly
+        "genome",                          // busco mode
+        val_busco_lineage,                 // lineage to run BUSCO predictions
+        val_busco_lineage_directory ?: [], // busco lineage directory
+        [],                                // busco config
+        true                               // clean intermediates
+    )
+    ch_versions = ch_versions.mix(BUSCO_BUSCO.out.versions)
+
+    //
+    // Module: assess kmer completeness/QV using MerquryFK
+    //
+    ch_merquryfk_asm_input = ch_assemblies
+        | combine(ch_reads_fastk)
+        | map { meta_asm, hap1, hap2, meta_fk, fk_hist, fk_ktabs ->
+            [meta_asm, fk_hist, fk_ktabs, hap1, hap2]
+        }
+
+    MERQURYFK_MERQURYFK(
+        ch_merquryfk_asm_input,
+        ch_mat_fastk.ifEmpty([[],[]]),
+        ch_pat_fastk.ifEmpty([[],[]])
+    )
+    ch_versions = ch_versions.mix(MERQURYFK_MERQURYFK.out.versions)
+    ch_merquryfk_images = MERQURYFK_MERQURYFK.out.spectra_cn_fl
+        | mix(
+            MERQURYFK_MERQURYFK.out.spectra_cn_fl,
+            MERQURYFK_MERQURYFK.out.spectra_cn_ln,
+            MERQURYFK_MERQURYFK.out.spectra_cn_st,
+            MERQURYFK_MERQURYFK.out.spectra_asm_fl,
+            MERQURYFK_MERQURYFK.out.spectra_cn_ln,
+            MERQURYFK_MERQURYFK.out.spectra_cn_st,
+            MERQURYFK_MERQURYFK.out.continuity_N,
+            MERQURYFK_MERQURYFK.out.block_N,
+            MERQURYFK_MERQURYFK.out.block_blob,
+            MERQURYFK_MERQURYFK.out.hapmers_blob,
+        )
+
+    emit:
+    asmstats             = ASMSTATS.out.stats
+    gfastats             = GFASTATS.out.assembly_summary
+    busco_summary_txt    = BUSCO_BUSCO.out.short_summaries_txt
+    busco_summary_json   = BUSCO_BUSCO.out.short_summaries_json
+    merqury_qv           = MERQURYFK_MERQURYFK.out.qv
+    merqury_completeness = MERQURYFK_MERQURYFK.out.stats
+    merqury_phased_stats = MERQURYFK_MERQURYFK.out.phased_block_stats
+    merqury_images       = ch_merquryfk_images
+    versions             = ch_versions
+
+}

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -20,7 +20,7 @@ workflow GENOME_STATISTICS {
         | flatMap { meta, asm1, asm2 ->
             def meta_asm1 = meta + [_hap: "hap1"]
             def meta_asm2 = meta + [_hap: "hap2"]
-            [ [meta_asm1, asm1], [meta_asm2, asm2] ]
+            return [ [meta_asm1, asm1], [meta_asm2, asm2] ]
         }
         | filter { meta, asm -> asm }
 
@@ -73,14 +73,15 @@ workflow GENOME_STATISTICS {
         ch_pat_fastk.ifEmpty([[],[]])
     )
     ch_versions = ch_versions.mix(MERQURYFK_MERQURYFK.out.versions)
-    ch_merquryfk_images = MERQURYFK_MERQURYFK.out.spectra_cn_fl
+
+    ch_merquryfk_images = Channel.empty()
         | mix(
             MERQURYFK_MERQURYFK.out.spectra_cn_fl,
             MERQURYFK_MERQURYFK.out.spectra_cn_ln,
             MERQURYFK_MERQURYFK.out.spectra_cn_st,
             MERQURYFK_MERQURYFK.out.spectra_asm_fl,
-            MERQURYFK_MERQURYFK.out.spectra_cn_ln,
-            MERQURYFK_MERQURYFK.out.spectra_cn_st,
+            MERQURYFK_MERQURYFK.out.spectra_asm_ln,
+            MERQURYFK_MERQURYFK.out.spectra_asm_st,
             MERQURYFK_MERQURYFK.out.continuity_N,
             MERQURYFK_MERQURYFK.out.block_N,
             MERQURYFK_MERQURYFK.out.block_blob,
@@ -97,5 +98,4 @@ workflow GENOME_STATISTICS {
     merqury_phased_stats = MERQURYFK_MERQURYFK.out.phased_block_stats
     merqury_images       = ch_merquryfk_images
     versions             = ch_versions
-
 }

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -49,10 +49,8 @@ workflow GENOME_STATISTICS {
     // Module: Assess assembly using BUSCO_BUSCO. If val_busco_lineage
     //         not provided then we properly skip the process entirely.
     //
-    ch_busco_lineage_input = Channel.empty()
-    if(val_busco_lineage) {
-        ch_busco_lineage_input = Channel.of(val_busco_lineage)
-    }
+    ch_busco_lineage_input = Channel.value(val_busco_lineage)
+        | filter { lineage -> lineage }
 
     BUSCO_BUSCO(
         ch_assemblies_split,               // assembly

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -93,6 +93,7 @@ workflow GENOME_STATISTICS {
             MERQURYFK_MERQURYFK.out.block_blob,
             MERQURYFK_MERQURYFK.out.hapmers_blob,
         )
+		| transpose()
 
     emit:
     asmstats             = ASMSTATS.out.stats

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -36,8 +36,8 @@ workflow GENOME_STATISTICS {
     GFASTATS(
         ch_assemblies_split, // assembly
         "fasta",             // out_fmt
-        [],                  // genome size
-        [],                  // target
+        "",                  // genome size
+        "",                  // target
         [[],[]],             // agp file
         [[],[]],             // include bed
         [[],[]],             // exclude bed

--- a/subworkflows/sanger-tol/genome_statistics/meta.yml
+++ b/subworkflows/sanger-tol/genome_statistics/meta.yml
@@ -1,45 +1,114 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
-name: "genomestatistics"
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/nf-core-modules/refs/heads/main/subworkflows/yaml-schema.json
+name: "genome_statistics"
 description: |
   Evaluate a number of standard metrics for a genome assembly, including
   basic statistics, MerquryFK for completeness/QV scores, and BUSCO
-
-  To match a FastK database to an assembly, it assumes that
 keywords:
   - assembly
   - qc
   - busco
   - merqury
 components:
-  - samtools/sort
-  - samtools/index
+  - asmstats
+  - gfastats:
+      git_remote: https://github.com/nf-core/modules.git
+  - busco/busco:
+      git_remote: https://github.com/nf-core/modules.git
+  - merquryfk/merquryfk:
+      git_remote: https://github.com/nf-core/modules.git
 input:
-  - ch_bam:
+  - ch_assemblies:
       type: file
       description: |
-        The input channel containing the BAM/CRAM/SAM files
-        Structure: [ val(meta), path(bam) ]
-      pattern: "*.{bam/cram/sam}"
-## TODO nf-core: List all of the channels used as output with a descriptions and their structure
+        The input channel containing a pair of assemblies for QC (hap1/hap2).
+        Hap2 can optionally be an empty list if there is no second hap.
+
+        Structure: [ val(meta), path(asm1), path(asm2) ]
+      pattern: "*.{fa,fa.gz}"
+  - ch_reads_fastk:
+      type: file
+      description: |
+        A channel containing FastK databases built from reads to compare the assemblies
+        against in MerquryFK.
+
+        Structure: [ val(meta), path(fastk_hist), path(fastk_ktabs) ]
+      pattern: "*.{.hist,.ktab}"
+  - ch_mat_fastk:
+      type: file
+      description: |
+        A channel containing a FastK database from MerquryFk/hapmaper containing maternal
+        kmers.
+
+        Structure: [ val(meta), path(fastk_hist), path(fastk_ktabs) ]
+      pattern: "*.{.hist,.ktab}"
+  - ch_pat_fastk:
+      type: file
+      description: |
+        A channel containing a FastK database from MerquryFk/hapmaper containing paternal
+        kmers.
+
+        Structure: [ val(meta), path(fastk_hist), path(fastk_ktabs) ]
+      pattern: "*.{.hist,.ktab}"
+  - val_busco_lineage:
+      type: string
+      description: |
+        The BUSCO lineage to use when assessing genome completeness with BUSCO.
+        Either the name of a lineage (e.g. "lepidoptera_odb12") or one of
+        "auto", "auto_euk", "auto_prok" to enable automatic lineage selection.
+  - val_busco_lineage_directory:
+      type: file
+      description: |
+        A path to a local directory containing pre-downloaded BUSCO lineages.
 output:
-  - bam:
+  - asmstats:
       type: file
       description: |
-        Channel containing BAM files
-        Structure: [ val(meta), path(bam) ]
+        Channel containing assembly statistics from asmstats.
+        Structure: [ val(meta), path(stats) ]
+      pattern: "*.stats"
+  - asmstats:
+      type: file
+      description: |
+        Channel containing assembly statistics from asmstats.
+        Structure: [ val(meta), path(stats) ]
       pattern: "*.bam"
-  - bai:
+  - busco_summary_txt:
       type: file
       description: |
-        Channel containing indexed BAM (BAI) files
-        Structure: [ val(meta), path(bai) ]
-      pattern: "*.bai"
-  - csi:
+        BUSCO summary in txt format.
+        Structure: [ val(meta), path(summary) ]
+      pattern: "*.txt"
+  - busco_summary_json:
       type: file
       description: |
-        Channel containing CSI files
-        Structure: [ val(meta), path(csi) ]
-      pattern: "*.csi"
+        BUSCO summary in JSON format.
+        Structure: [ val(meta), path(summary) ]
+      pattern: "*.json"
+  - merqury_qv:
+      type: file
+      description: |
+        MerquryFK QV estimates for each assembly.
+        Structure: [ val(meta), path(qv) ]
+      pattern: "*.qv"
+  - merqury_completeness:
+      type: file
+      description: |
+        MerquryFK kmer completeness estimates for each assembly.
+        Structure: [ val(meta), path(completeness) ]
+      pattern: "*.completeness.stats"
+  - merqury_phased_stats:
+      type: file
+      description: |
+        MerquryFK kmer phasing estimates for each assembly.
+        Structure: [ val(meta), path(phasing) ]
+      pattern: "*.phased_block.stats"
+  - merqury_images:
+      type: file
+      description: |
+        MerquryFK plots - both CNI, ASM and phasing.
+
+        Structure: [ val(meta), path(image) ]
+      pattern: "*.{png,pdf}"
   - versions:
       type: file
       description: |

--- a/subworkflows/sanger-tol/genome_statistics/meta.yml
+++ b/subworkflows/sanger-tol/genome_statistics/meta.yml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "genomestatistics"
+description: |
+  Evaluate a number of standard metrics for a genome assembly, including
+  basic statistics, MerquryFK for completeness/QV scores, and BUSCO
+
+  To match a FastK database to an assembly, it assumes that
+keywords:
+  - assembly
+  - qc
+  - busco
+  - merqury
+components:
+  - samtools/sort
+  - samtools/index
+input:
+  - ch_bam:
+      type: file
+      description: |
+        The input channel containing the BAM/CRAM/SAM files
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.{bam/cram/sam}"
+## TODO nf-core: List all of the channels used as output with a descriptions and their structure
+output:
+  - bam:
+      type: file
+      description: |
+        Channel containing BAM files
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - bai:
+      type: file
+      description: |
+        Channel containing indexed BAM (BAI) files
+        Structure: [ val(meta), path(bai) ]
+      pattern: "*.bai"
+  - csi:
+      type: file
+      description: |
+        Channel containing CSI files
+        Structure: [ val(meta), path(csi) ]
+      pattern: "*.csi"
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@prototaxites"
+maintainers:
+  - "@prototaxites"

--- a/subworkflows/sanger-tol/genome_statistics/tests/fastk.config
+++ b/subworkflows/sanger-tol/genome_statistics/tests/fastk.config
@@ -1,0 +1,7 @@
+nextflow.enable.moduleBinaries = true
+
+process {
+    withName: FASTK_FASTK {
+        ext.args = params.fastk_args
+    }
+}

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -13,6 +13,53 @@ nextflow_workflow {
     tag "subworkflows/../../modules/nf-core/merquryfk/merquryfk"
     tag "modules/nf-core/fastk/fastk"
 
+    test("meles meles - no trio - no busco - no fastk") {
+
+        config "./no_fastk.config"
+
+        setup {
+            nfcoreInitialise("${launchDir}/library/")
+            nfcoreInstall(
+                "${launchDir}/library/",
+                [
+                    "busco/busco",
+                    "gfastats",
+                    "merquryfk/merquryfk",
+                ]
+            )
+            nfcoreLink("${launchDir}/library/", "${baseDir}/modules/")
+        }
+
+        when {
+
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: "test"],
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859975.1_alt.fasta.gz', checkIfExists: true)
+                ])
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
+                input[3] = Channel.empty()
+                input[4] = ""
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success               },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+
+        cleanup {
+            nfcoreUnlink("${launchDir}/library/", "${baseDir}/modules/nf-core")
+        }
+    }
+
     test("meles meles - no trio - no fastk") {
 
         config "./no_fastk.config"
@@ -50,8 +97,32 @@ nextflow_workflow {
 
         then {
             assertAll(
-                { assert workflow.success               },
-                { assert snapshot(workflow.out).match() }
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.asmstats,
+                    workflow.out.gfastats,
+                    workflow.out.merqury_qv,
+                    workflow.out.merqury_completeness,
+                    workflow.out.merqury_phased_stats,
+                    workflow.out.merqury_images,
+                    workflow.out.versions
+                    ).match()
+                },
+                { assert with(path(workflow.out.busco_summary_txt[0][1]).text) {
+                        assert contains('BUSCO version')
+                        assert contains('The lineage dataset is')
+                        assert contains('BUSCO was run in mode')
+                        assert contains('Complete BUSCOs')
+                        assert contains('Missing BUSCOs')
+                        assert contains('Dependencies and versions')
+                    }
+                }
+                { assert with(path(workflow.out.busco_summary_json[0][1]).text) {
+                    assert contains('one_line_summary')
+                    assert contains('mode')
+                    assert contains('dataset')
+                    }
+                }
             )
         }
 
@@ -115,8 +186,32 @@ nextflow_workflow {
 
         then {
             assertAll(
-                { assert workflow.success               },
-                { assert snapshot(workflow.out).match() }
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.asmstats,
+                    workflow.out.gfastats,
+                    workflow.out.merqury_qv,
+                    workflow.out.merqury_completeness,
+                    workflow.out.merqury_phased_stats,
+                    workflow.out.merqury_images,
+                    workflow.out.versions
+                    ).match()
+                },
+                { assert with(path(workflow.out.busco_summary_txt[0][1]).text) {
+                        assert contains('BUSCO version')
+                        assert contains('The lineage dataset is')
+                        assert contains('BUSCO was run in mode')
+                        assert contains('Complete BUSCOs')
+                        assert contains('Missing BUSCOs')
+                        assert contains('Dependencies and versions')
+                    }
+                }
+                { assert with(path(workflow.out.busco_summary_json[0][1]).text) {
+                    assert contains('one_line_summary')
+                    assert contains('mode')
+                    assert contains('dataset')
+                    }
+                }
             )
         }
 

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -1,0 +1,127 @@
+nextflow_workflow {
+
+    name "Test Subworkflow GENOME_STATISTICS"
+    script "../main.nf"
+    workflow "GENOME_STATISTICS"
+
+    tag "subworkflows"
+    tag "subworkflows_sangertol"
+    tag "subworkflows/genome_statistics"
+    tag "asmstats"
+    tag "subworkflows/../../modules/nf-core/busco/busco"
+    tag "subworkflows/../../modules/nf-core/gfastats"
+    tag "subworkflows/../../modules/nf-core/merquryfk/merquryfk"
+
+    test("meles meles - no trio - no fastk") {
+
+        config "./no_fastk.config"
+
+        setup {
+            nfcoreInitialise("${launchDir}/library/")
+            nfcoreInstall(
+                "${launchDir}/library/",
+                [
+                    "busco/busco",
+                    "gfastats",
+                    "merquryfk/merquryfk",
+                ]
+            )
+            nfcoreLink("${launchDir}/library/", "${baseDir}/modules/")
+        }
+
+        when {
+
+            workflow {
+                """
+                input[0] = [
+                    [ id: "test"],
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
+                input[3] = Channel.empty()
+                input[4] = "lepidoptera_odb12"
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success               },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+
+        cleanup {
+            nfcoreUnlink("${launchDir}/library/", "${baseDir}/modules/nf-core")
+        }
+    }
+
+    test("meles meles - no trio - fastk") {
+
+        config "./fastk.config"
+
+        setup {
+            nfcoreInitialise("${launchDir}/library/")
+            nfcoreInstall(
+                "${launchDir}/library/",
+                [
+                    "busco/busco",
+                    "gfastats",
+                    "merquryfk/merquryfk",
+                    "fastk/fastk",
+                ]
+            )
+            nfcoreLink("${launchDir}/library/", "${baseDir}/modules/")
+
+            run("FASTK_FASTK") {
+                script "../../../../nf-core/fastk/fastk/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: "test" ],
+                        file(params.modules_testdata_base_path + 'Ceramica_pisi/genomic_data/ilCerPisi1/pacbio/m64097e_230309_154741.ccs.bc1012_BAK8A_OA--bc1012_BAK8A_OA.subsampled.bam', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+
+        }
+
+        when {
+
+            params {
+                fastk_args = "-t"
+            }
+
+            workflow {
+                """
+                input[0] = [
+                    [ id: "test"],
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = FASTK_FASTK.out.hist.join(FASTK_FASTK.out.ktab)
+                input[2] = Channel.empty()
+                input[3] = Channel.empty()
+                input[4] = "lepidoptera_odb12"
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success               },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+
+        cleanup {
+            nfcoreUnlink("${launchDir}/library/", "${baseDir}/modules/nf-core")
+        }
+    }
+
+}

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -36,7 +36,7 @@ nextflow_workflow {
                 input[0] = Channel.of([
                     [ id: "test"],
                     file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859975.1_alt.fasta.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.empty()
                 input[2] = Channel.empty()
@@ -101,7 +101,7 @@ nextflow_workflow {
                 input[0] = Channel.of([
                     [ id: "test"],
                     file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859975.1_alt.fasta.gz', checkIfExists: true)
                 ])
                 input[1] = FASTK_FASTK.out.hist.join(FASTK_FASTK.out.ktab)
                 input[2] = Channel.empty()

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -36,8 +36,8 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                     [ id: "test"],
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859975.1_alt.fasta.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap1.p_ctg.fa.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap2.p_ctg.fa.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.empty()
                 input[2] = Channel.empty()
@@ -83,13 +83,13 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                     [ id: "test"],
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859975.1_alt.fasta.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap1.p_ctg.fa.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap2.p_ctg.fa.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.empty()
                 input[2] = Channel.empty()
                 input[3] = Channel.empty()
-                input[4] = "lepidoptera_odb12"
+                input[4] = "bacteria_odb12"
                 input[5] = []
                 """
             }
@@ -147,7 +147,7 @@ nextflow_workflow {
                     """
                     input[0] = [
                         [ id: "test" ],
-                        file(params.modules_testdata_base_path + 'Ceramica_pisi/genomic_data/ilCerPisi1/pacbio/m64097e_230309_154741.ccs.bc1012_BAK8A_OA--bc1012_BAK8A_OA.subsampled.bam', checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'Undibacterium_unclassified/genomic_data/baUndUnlc1/pacbio/fasta/HiFi.reads.fasta', checkIfExists: true)
                     ]
                     """
                 }
@@ -165,13 +165,13 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                     [ id: "test"],
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859975.1_alt.fasta.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap1.p_ctg.fa.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap2.p_ctg.fa.gz', checkIfExists: true)
                 ])
                 input[1] = FASTK_FASTK.out.hist.join(FASTK_FASTK.out.ktab)
                 input[2] = Channel.empty()
                 input[3] = Channel.empty()
-                input[4] = "lepidoptera_odb12"
+                input[4] = "bacteria_odb12"
                 input[5] = []
                 """
             }

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -98,8 +98,14 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.busco_summary_txt != null  },
-                { assert workflow.out.busco_summary_json != null },
+                { assert workflow.out.busco_summary_txt
+                    .collect { meta, txt -> path(txt).text.contains("Complete BUSCOs") }
+                    .every()
+                },
+                { assert workflow.out.busco_summary_json
+                    .collect { meta, json -> path(json).text.contains("one_line_summary") }
+                    .every()
+                },
                 { assert snapshot(
                     workflow.out.asmstats,
                     workflow.out.gfastats,
@@ -174,8 +180,14 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.busco_summary_txt != null  },
-                { assert workflow.out.busco_summary_json != null },
+                { assert workflow.out.busco_summary_txt
+                    .collect { meta, txt -> path(txt).text.contains("Complete BUSCOs") }
+                    .every()
+                },
+                { assert workflow.out.busco_summary_json
+                    .collect { meta, json -> path(json).text.contains("one_line_summary") }
+                    .every()
+                },
                 { assert snapshot(
                     workflow.out.asmstats,
                     workflow.out.gfastats,

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -11,6 +11,7 @@ nextflow_workflow {
     tag "subworkflows/../../modules/nf-core/busco/busco"
     tag "subworkflows/../../modules/nf-core/gfastats"
     tag "subworkflows/../../modules/nf-core/merquryfk/merquryfk"
+    tag "modules/nf-core/fastk/fastk"
 
     test("meles meles - no trio - no fastk") {
 

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -112,7 +112,7 @@ nextflow_workflow {
                     workflow.out.merqury_qv,
                     workflow.out.merqury_completeness,
                     workflow.out.merqury_phased_stats,
-                    workflow.out.merqury_images,
+                    workflow.out.merqury_images.collect { meta, image -> [meta, file(image).name] },
                     workflow.out.versions
                     ).match()
                 }
@@ -194,7 +194,7 @@ nextflow_workflow {
                     workflow.out.merqury_qv,
                     workflow.out.merqury_completeness,
                     workflow.out.merqury_phased_stats,
-                    workflow.out.merqury_images,
+                    workflow.out.merqury_images.collect { meta, image -> [meta, file(image).name] },
                     workflow.out.versions
                     ).match()
                 }

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -98,6 +98,8 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert workflow.out.busco_summary_txt != null  },
+                { assert workflow.out.busco_summary_json != null },
                 { assert snapshot(
                     workflow.out.asmstats,
                     workflow.out.gfastats,
@@ -107,21 +109,6 @@ nextflow_workflow {
                     workflow.out.merqury_images,
                     workflow.out.versions
                     ).match()
-                },
-                { assert with(path(workflow.out.busco_summary_txt[0][1]).text) {
-                        assert contains('BUSCO version')
-                        assert contains('The lineage dataset is')
-                        assert contains('BUSCO was run in mode')
-                        assert contains('Complete BUSCOs')
-                        assert contains('Missing BUSCOs')
-                        assert contains('Dependencies and versions')
-                    }
-                }
-                { assert with(path(workflow.out.busco_summary_json[0][1]).text) {
-                    assert contains('one_line_summary')
-                    assert contains('mode')
-                    assert contains('dataset')
-                    }
                 }
             )
         }
@@ -187,6 +174,8 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert workflow.out.busco_summary_txt != null  },
+                { assert workflow.out.busco_summary_json != null },
                 { assert snapshot(
                     workflow.out.asmstats,
                     workflow.out.gfastats,
@@ -196,21 +185,6 @@ nextflow_workflow {
                     workflow.out.merqury_images,
                     workflow.out.versions
                     ).match()
-                },
-                { assert with(path(workflow.out.busco_summary_txt[0][1]).text) {
-                        assert contains('BUSCO version')
-                        assert contains('The lineage dataset is')
-                        assert contains('BUSCO was run in mode')
-                        assert contains('Complete BUSCOs')
-                        assert contains('Missing BUSCOs')
-                        assert contains('Dependencies and versions')
-                    }
-                }
-                { assert with(path(workflow.out.busco_summary_json[0][1]).text) {
-                    assert contains('one_line_summary')
-                    assert contains('mode')
-                    assert contains('dataset')
-                    }
                 }
             )
         }

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -33,11 +33,11 @@ nextflow_workflow {
 
             workflow {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                     [ id: "test"],
                     file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true)
-                ]
+                ])
                 input[1] = Channel.empty()
                 input[2] = Channel.empty()
                 input[3] = Channel.empty()
@@ -77,7 +77,7 @@ nextflow_workflow {
             nfcoreLink("${launchDir}/library/", "${baseDir}/modules/")
 
             run("FASTK_FASTK") {
-                script "../../../../nf-core/fastk/fastk/main.nf"
+                script "../../../../modules/nf-core/fastk/fastk/main.nf"
                 process {
                     """
                     input[0] = [
@@ -98,11 +98,11 @@ nextflow_workflow {
 
             workflow {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                     [ id: "test"],
                     file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz', checkIfExists: true)
-                ]
+                ])
                 input[1] = FASTK_FASTK.out.hist.join(FASTK_FASTK.out.ktab)
                 input[2] = Channel.empty()
                 input[3] = Channel.empty()

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
@@ -117,19 +117,37 @@
                     {
                         "id": "test"
                     },
-                    [
-                        "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45",
-                        "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
-                    ]
+                    "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    [
-                        "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8",
-                        "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
-                    ]
+                    "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
                 ],
                 [
                     {
@@ -148,15 +166,6 @@
                         "id": "test"
                     },
                     "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
-                ],
-                [
-                    {
-                        "id": "test"
-                    },
-                    [
-                        "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61",
-                        "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
-                    ]
                 ]
             ],
             [
@@ -172,7 +181,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-01T19:19:42.294970467"
+        "timestamp": "2025-09-02T09:53:02.711938626"
     },
     "meles meles - no trio - no busco - no fastk": {
         "content": [

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
@@ -47,6 +47,7 @@
             ],
             [
                 "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
                 "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
                 "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
                 "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
@@ -57,7 +58,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-01T18:57:36.408961885"
+        "timestamp": "2025-09-02T12:22:29.99745606"
     },
     "meles meles - no trio - fastk": {
         "content": [
@@ -117,58 +118,59 @@
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45"
+                    "test.GCA_963859965.1.spectra-cn.fl.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61"
+                    "test.GCA_963859965.1.spectra-cn.ln.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8"
+                    "test.GCA_963859965.1.spectra-cn.st.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
+                    "test.GCA_963859975.1_alt.spectra-cn.fl.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
+                    "test.GCA_963859975.1_alt.spectra-cn.ln.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
+                    "test.GCA_963859975.1_alt.spectra-cn.st.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.spectra-asm.fl.png:md5,4a805b352b0c3d58a260da186b464c0d"
+                    "test.spectra-asm.fl.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.spectra-asm.ln.png:md5,1da92137877b50f5aa8a0b6758cfa533"
+                    "test.spectra-asm.ln.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
+                    "test.spectra-asm.st.png"
                 ]
             ],
             [
+                "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
                 "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
                 "versions.yml:md5,6ca1cfcfe9de105329f67f268cfdeeeb",
                 "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
@@ -181,7 +183,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-02T09:53:02.711938626"
+        "timestamp": "2025-09-02T12:45:26.75061184"
     },
     "meles meles - no trio - no busco - no fastk": {
         "content": [

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
@@ -1,184 +1,180 @@
 {
     "meles meles - no trio - no fastk": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
-                    ]
+            [
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap1"
+                    },
+                    "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
                 ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,607f3627caada26218232b9232edb8b5"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,e93b2e32f123ab36706bc5a0a9eaaf04"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,9081ab8cd0aa8f00ecfc7c3f8c9ebee0"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,8d78a24eeb4d4b54d072cc2d78499dba"
-                    ]
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
-                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
-                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
-                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
-                ],
-                "asmstats": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
-                    ]
-                ],
-                "busco_summary_json": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,9081ab8cd0aa8f00ecfc7c3f8c9ebee0"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,8d78a24eeb4d4b54d072cc2d78499dba"
-                    ]
-                ],
-                "busco_summary_txt": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,607f3627caada26218232b9232edb8b5"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,e93b2e32f123ab36706bc5a0a9eaaf04"
-                    ]
-                ],
-                "gfastats": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
-                    ]
-                ],
-                "merqury_completeness": [
-                    
-                ],
-                "merqury_images": [
-                    
-                ],
-                "merqury_phased_stats": [
-                    
-                ],
-                "merqury_qv": [
-                    
-                ],
-                "versions": [
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
-                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
-                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
-                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap2"
+                    },
+                    "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap1"
+                    },
+                    "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap2"
+                    },
+                    "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
+                "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-01T14:49:29.885520833"
+        "timestamp": "2025-09-01T18:57:36.408961885"
     },
     "meles meles - no trio - fastk": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap1"
+                    },
+                    "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap2"
+                    },
+                    "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap1"
+                    },
+                    "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "_hap": "hap2"
+                    },
+                    "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.qv:md5,2ad445619abaea809f86268872c1bdae"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.completeness.stats:md5,4499c462a6cae00678eefdeb898e8513"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45",
+                        "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
+                    ]
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8",
+                        "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
+                    ]
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.spectra-asm.fl.png:md5,4a805b352b0c3d58a260da186b464c0d"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.spectra-asm.ln.png:md5,1da92137877b50f5aa8a0b6758cfa533"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
+                ],
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61",
+                        "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                "versions.yml:md5,6ca1cfcfe9de105329f67f268cfdeeeb",
+                "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
+                "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-09-01T19:19:42.294970467"
+    },
+    "meles meles - no trio - no busco - no fastk": {
         "content": [
             {
                 "0": [
@@ -214,107 +210,24 @@
                     ]
                 ],
                 "2": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,303cbb08dfef891b26420741690ed3af"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,d29274d3b64591598c4ff13434f83ffb"
-                    ]
+                    
                 ],
                 "3": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,785e29b8ab58ab9849da7f7e671d8ebb"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,2cc47942c5c30b8da3769a6823a7fe8a"
-                    ]
+                    
                 ],
                 "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.qv:md5,2ad445619abaea809f86268872c1bdae"
-                    ]
+                    
                 ],
                 "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.completeness.stats:md5,4499c462a6cae00678eefdeb898e8513"
-                    ]
+                    
                 ],
                 "6": [
                     
                 ],
                 "7": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45",
-                            "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
-                        ]
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.spectra-asm.ln.png:md5,1da92137877b50f5aa8a0b6758cfa533"
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61",
-                            "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
-                        ]
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.spectra-asm.fl.png:md5,4a805b352b0c3d58a260da186b464c0d"
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8",
-                            "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
-                        ]
-                    ]
+                    
                 ],
                 "8": [
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,6ca1cfcfe9de105329f67f268cfdeeeb",
                     "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
                     "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
                     "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
@@ -337,36 +250,10 @@
                     ]
                 ],
                 "busco_summary_json": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,785e29b8ab58ab9849da7f7e671d8ebb"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,2cc47942c5c30b8da3769a6823a7fe8a"
-                    ]
+                    
                 ],
                 "busco_summary_txt": [
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap1"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,303cbb08dfef891b26420741690ed3af"
-                    ],
-                    [
-                        {
-                            "id": "test",
-                            "_hap": "hap2"
-                        },
-                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,d29274d3b64591598c4ff13434f83ffb"
-                    ]
+                    
                 ],
                 "gfastats": [
                     [
@@ -385,75 +272,18 @@
                     ]
                 ],
                 "merqury_completeness": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.completeness.stats:md5,4499c462a6cae00678eefdeb898e8513"
-                    ]
+                    
                 ],
                 "merqury_images": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45",
-                            "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
-                        ]
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.spectra-asm.ln.png:md5,1da92137877b50f5aa8a0b6758cfa533"
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61",
-                            "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
-                        ]
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.spectra-asm.fl.png:md5,4a805b352b0c3d58a260da186b464c0d"
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
-                    ],
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8",
-                            "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
-                        ]
-                    ]
+                    
                 ],
                 "merqury_phased_stats": [
                     
                 ],
                 "merqury_qv": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.qv:md5,2ad445619abaea809f86268872c1bdae"
-                    ]
+                    
                 ],
                 "versions": [
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
-                    "versions.yml:md5,6ca1cfcfe9de105329f67f268cfdeeeb",
                     "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
                     "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
                     "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
@@ -465,6 +295,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-01T15:11:22.405129542"
+        "timestamp": "2025-09-01T16:56:02.670048879"
     }
 }

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
@@ -7,14 +7,14 @@
                         "id": "test",
                         "_hap": "hap1"
                     },
-                    "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                    "baUndUnlc1.hic.hap1.p_ctg.fa.gz.stats:md5,2ed748b50332840fdbba4e472681f6e7"
                 ],
                 [
                     {
                         "id": "test",
                         "_hap": "hap2"
                     },
-                    "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                    "baUndUnlc1.hic.hap2.p_ctg.fa.gz.stats:md5,cb3b18c6cdca1d3df3565d4c5b842d86"
                 ]
             ],
             [
@@ -23,14 +23,14 @@
                         "id": "test",
                         "_hap": "hap1"
                     },
-                    "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                    "test.assembly_summary:md5,1a9954f4d2d0347a04e0e115c0556d96"
                 ],
                 [
                     {
                         "id": "test",
                         "_hap": "hap2"
                     },
-                    "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                    "test.assembly_summary:md5,08214ac5e67c7ebf49104c2212936437"
                 ]
             ],
             [
@@ -58,7 +58,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-02T12:22:29.99745606"
+        "timestamp": "2025-09-02T14:02:18.380027698"
     },
     "meles meles - no trio - fastk": {
         "content": [
@@ -68,14 +68,14 @@
                         "id": "test",
                         "_hap": "hap1"
                     },
-                    "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                    "baUndUnlc1.hic.hap1.p_ctg.fa.gz.stats:md5,2ed748b50332840fdbba4e472681f6e7"
                 ],
                 [
                     {
                         "id": "test",
                         "_hap": "hap2"
                     },
-                    "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                    "baUndUnlc1.hic.hap2.p_ctg.fa.gz.stats:md5,cb3b18c6cdca1d3df3565d4c5b842d86"
                 ]
             ],
             [
@@ -84,14 +84,14 @@
                         "id": "test",
                         "_hap": "hap1"
                     },
-                    "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                    "test.assembly_summary:md5,1a9954f4d2d0347a04e0e115c0556d96"
                 ],
                 [
                     {
                         "id": "test",
                         "_hap": "hap2"
                     },
-                    "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                    "test.assembly_summary:md5,08214ac5e67c7ebf49104c2212936437"
                 ]
             ],
             [
@@ -99,7 +99,7 @@
                     {
                         "id": "test"
                     },
-                    "test.qv:md5,2ad445619abaea809f86268872c1bdae"
+                    "test.qv:md5,5754802f3d1e6e84365dcf8bbf549343"
                 ]
             ],
             [
@@ -107,7 +107,7 @@
                     {
                         "id": "test"
                     },
-                    "test.completeness.stats:md5,4499c462a6cae00678eefdeb898e8513"
+                    "test.completeness.stats:md5,51b412fa6dcaccdd0c7f5b46e6db0d0b"
                 ]
             ],
             [
@@ -118,37 +118,37 @@
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859965.1.spectra-cn.fl.png"
+                    "test.baUndUnlc1.hic.hap1.p_ctg.spectra-cn.fl.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859965.1.spectra-cn.ln.png"
+                    "test.baUndUnlc1.hic.hap1.p_ctg.spectra-cn.ln.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859965.1.spectra-cn.st.png"
+                    "test.baUndUnlc1.hic.hap1.p_ctg.spectra-cn.st.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859975.1_alt.spectra-cn.fl.png"
+                    "test.baUndUnlc1.hic.hap2.p_ctg.spectra-cn.fl.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859975.1_alt.spectra-cn.ln.png"
+                    "test.baUndUnlc1.hic.hap2.p_ctg.spectra-cn.ln.png"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.GCA_963859975.1_alt.spectra-cn.st.png"
+                    "test.baUndUnlc1.hic.hap2.p_ctg.spectra-cn.st.png"
                 ],
                 [
                     {
@@ -183,7 +183,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-02T12:45:26.75061184"
+        "timestamp": "2025-09-02T14:04:52.534157712"
     },
     "meles meles - no trio - no busco - no fastk": {
         "content": [
@@ -194,14 +194,14 @@
                             "id": "test",
                             "_hap": "hap1"
                         },
-                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                        "baUndUnlc1.hic.hap1.p_ctg.fa.gz.stats:md5,2ed748b50332840fdbba4e472681f6e7"
                     ],
                     [
                         {
                             "id": "test",
                             "_hap": "hap2"
                         },
-                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                        "baUndUnlc1.hic.hap2.p_ctg.fa.gz.stats:md5,cb3b18c6cdca1d3df3565d4c5b842d86"
                     ]
                 ],
                 "1": [
@@ -210,14 +210,14 @@
                             "id": "test",
                             "_hap": "hap1"
                         },
-                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                        "test.assembly_summary:md5,1a9954f4d2d0347a04e0e115c0556d96"
                     ],
                     [
                         {
                             "id": "test",
                             "_hap": "hap2"
                         },
-                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                        "test.assembly_summary:md5,08214ac5e67c7ebf49104c2212936437"
                     ]
                 ],
                 "2": [
@@ -250,14 +250,14 @@
                             "id": "test",
                             "_hap": "hap1"
                         },
-                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                        "baUndUnlc1.hic.hap1.p_ctg.fa.gz.stats:md5,2ed748b50332840fdbba4e472681f6e7"
                     ],
                     [
                         {
                             "id": "test",
                             "_hap": "hap2"
                         },
-                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                        "baUndUnlc1.hic.hap2.p_ctg.fa.gz.stats:md5,cb3b18c6cdca1d3df3565d4c5b842d86"
                     ]
                 ],
                 "busco_summary_json": [
@@ -272,14 +272,14 @@
                             "id": "test",
                             "_hap": "hap1"
                         },
-                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                        "test.assembly_summary:md5,1a9954f4d2d0347a04e0e115c0556d96"
                     ],
                     [
                         {
                             "id": "test",
                             "_hap": "hap2"
                         },
-                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                        "test.assembly_summary:md5,08214ac5e67c7ebf49104c2212936437"
                     ]
                 ],
                 "merqury_completeness": [
@@ -306,6 +306,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-09-01T16:56:02.670048879"
+        "timestamp": "2025-09-02T13:57:25.355266248"
     }
 }

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test.snap
@@ -1,0 +1,470 @@
+{
+    "meles meles - no trio - no fastk": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,607f3627caada26218232b9232edb8b5"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,e93b2e32f123ab36706bc5a0a9eaaf04"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,9081ab8cd0aa8f00ecfc7c3f8c9ebee0"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,8d78a24eeb4d4b54d072cc2d78499dba"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    
+                ],
+                "8": [
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+                ],
+                "asmstats": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                    ]
+                ],
+                "busco_summary_json": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,9081ab8cd0aa8f00ecfc7c3f8c9ebee0"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,8d78a24eeb4d4b54d072cc2d78499dba"
+                    ]
+                ],
+                "busco_summary_txt": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,607f3627caada26218232b9232edb8b5"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,e93b2e32f123ab36706bc5a0a9eaaf04"
+                    ]
+                ],
+                "gfastats": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                    ]
+                ],
+                "merqury_completeness": [
+                    
+                ],
+                "merqury_images": [
+                    
+                ],
+                "merqury_phased_stats": [
+                    
+                ],
+                "merqury_qv": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-09-01T14:49:29.885520833"
+    },
+    "meles meles - no trio - fastk": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,303cbb08dfef891b26420741690ed3af"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,d29274d3b64591598c4ff13434f83ffb"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,785e29b8ab58ab9849da7f7e671d8ebb"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,2cc47942c5c30b8da3769a6823a7fe8a"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.qv:md5,2ad445619abaea809f86268872c1bdae"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.completeness.stats:md5,4499c462a6cae00678eefdeb898e8513"
+                    ]
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45",
+                            "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
+                        ]
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.spectra-asm.ln.png:md5,1da92137877b50f5aa8a0b6758cfa533"
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61",
+                            "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
+                        ]
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.spectra-asm.fl.png:md5,4a805b352b0c3d58a260da186b464c0d"
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8",
+                            "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
+                        ]
+                    ]
+                ],
+                "8": [
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,6ca1cfcfe9de105329f67f268cfdeeeb",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+                ],
+                "asmstats": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "GCA_963859965.1.fasta.gz.stats:md5,27e0c97332ed50fbae78572581db1b56"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "GCA_963859975.1_alt.fasta.gz.stats:md5,bf5abf082c028eee5fbae15da09d9100"
+                    ]
+                ],
+                "busco_summary_json": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.json:md5,785e29b8ab58ab9849da7f7e671d8ebb"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.json:md5,2cc47942c5c30b8da3769a6823a7fe8a"
+                    ]
+                ],
+                "busco_summary_txt": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859965.1.fasta.txt:md5,303cbb08dfef891b26420741690ed3af"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "short_summary.specific.lepidoptera_odb12.GCA_963859975.1_alt.fasta.txt:md5,d29274d3b64591598c4ff13434f83ffb"
+                    ]
+                ],
+                "gfastats": [
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap1"
+                        },
+                        "test.assembly_summary:md5,03bd6448d99f284cee9224e932c26336"
+                    ],
+                    [
+                        {
+                            "id": "test",
+                            "_hap": "hap2"
+                        },
+                        "test.assembly_summary:md5,36a8cadec7d7dfd1ec7a922261cf95be"
+                    ]
+                ],
+                "merqury_completeness": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.completeness.stats:md5,4499c462a6cae00678eefdeb898e8513"
+                    ]
+                ],
+                "merqury_images": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.GCA_963859965.1.spectra-cn.fl.png:md5,c7bd0b65f7fe2a278d8e8342cf24dc45",
+                            "test.GCA_963859975.1_alt.spectra-cn.fl.png:md5,faa973397243a56ca290203fbcf2ca62"
+                        ]
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.spectra-asm.ln.png:md5,1da92137877b50f5aa8a0b6758cfa533"
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.GCA_963859965.1.spectra-cn.ln.png:md5,9e105e1a4bd8b97bc7a0c17075053f61",
+                            "test.GCA_963859975.1_alt.spectra-cn.ln.png:md5,82d5022abd9140e46d0e32e0804d1807"
+                        ]
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.spectra-asm.fl.png:md5,4a805b352b0c3d58a260da186b464c0d"
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.spectra-asm.st.png:md5,c16709e5d4bbba67cc16ba1af4f1692b"
+                    ],
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.GCA_963859965.1.spectra-cn.st.png:md5,fded9bf30138acdf0d94e542c2f950b8",
+                            "test.GCA_963859975.1_alt.spectra-cn.st.png:md5,e87c4c5ade1e82f341d491660496ae7e"
+                        ]
+                    ]
+                ],
+                "merqury_phased_stats": [
+                    
+                ],
+                "merqury_qv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.qv:md5,2ad445619abaea809f86268872c1bdae"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,09622cb9d9239872f0aa737cff7a2d5f",
+                    "versions.yml:md5,6ca1cfcfe9de105329f67f268cfdeeeb",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,ae8574670b9067c621698ce70bdfac49",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36",
+                    "versions.yml:md5,e162b266a7bfe9ab0ae9716e929feb36"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-09-01T15:11:22.405129542"
+    }
+}

--- a/subworkflows/sanger-tol/genome_statistics/tests/no_fastk.config
+++ b/subworkflows/sanger-tol/genome_statistics/tests/no_fastk.config
@@ -1,0 +1,1 @@
+nextflow.enable.moduleBinaries = true


### PR DESCRIPTION
Adds a generic genome statistics subworkflow. 

Takes as input a pair of assemblies (meta, hap1, hap2), then runs:

- asmstats (new module)
- gfastats
- busco
- merquryfk

Hap2 can optionally be missing. Adds a `_hap` tag to the meta to facilitate re-joining in downstream applications.