### PR TITLE
Genome statistics bugfix

### DIFF
--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -46,16 +46,12 @@ workflow GENOME_STATISTICS {
     ch_versions = ch_versions.mix(GFASTATS.out.versions)
 
     //
-    // Module: Assess assembly using BUSCO_BUSCO. If val_busco_lineage
-    //         not provided then we properly skip the process entirely.
+    // Module: Assess assembly using BUSCO. 
     //
-    ch_busco_lineage_input = Channel.value(val_busco_lineage)
-        | filter { lineage -> lineage }
-
     BUSCO_BUSCO(
         ch_assemblies_split,               // assembly
         "genome",                          // busco mode
-        ch_busco_lineage_input,            // lineage to run BUSCO predictions
+        val_busco_lineage,                 // lineage to run BUSCO predictions
         val_busco_lineage_directory ?: [], // busco lineage directory
         [],                                // busco config
         true                               // clean intermediates

--- a/subworkflows/sanger-tol/genome_statistics/main.nf
+++ b/subworkflows/sanger-tol/genome_statistics/main.nf
@@ -46,7 +46,7 @@ workflow GENOME_STATISTICS {
     ch_versions = ch_versions.mix(GFASTATS.out.versions)
 
     //
-    // Module: Assess assembly using BUSCO. 
+    // Module: Assess assembly using BUSCO.
     //
     BUSCO_BUSCO(
         ch_assemblies_split,               // assembly

--- a/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
+++ b/subworkflows/sanger-tol/genome_statistics/tests/main.nf.test
@@ -42,7 +42,7 @@ nextflow_workflow {
                 input[1] = Channel.empty()
                 input[2] = Channel.empty()
                 input[3] = Channel.empty()
-                input[4] = ""
+                input[4] = Channel.empty()
                 input[5] = []
                 """
             }


### PR DESCRIPTION
Removes the val_busco_lineage filtering as it didn't work in practice. 

User should either provide a string, and this will be implicitly converted to a value channel, or provide a value channel.