### PR TITLE
Hi-C mapping: join on metas to allow multiple crams

### DIFF
--- a/modules/sanger-tol/cramalign/gencramchunks/main.nf
+++ b/modules/sanger-tol/cramalign/gencramchunks/main.nf
@@ -4,12 +4,12 @@ process CRAMALIGN_GENCRAMCHUNKS {
 
     input:
     // Native processes can't take path values as inputs
-    tuple val(meta), val(cram), val(crai)
+    tuple val(meta), val(crai)
     val cram_bin_size
 
     output:
-    tuple val(meta), val(cram), val(crai), val(chunkn), val(slices), emit: cram_slices
-    path("versions.yml")                                           , emit: versions
+    tuple val(meta), val(chunkn), val(slices), emit: cram_slices
+    path("versions.yml")                     , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/sanger-tol/cramalign/gencramchunks/tests/main.nf.test
+++ b/modules/sanger-tol/cramalign/gencramchunks/tests/main.nf.test
@@ -16,7 +16,6 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.modules_testdata_base_path + 'Undibacterium_unclassified/genomic_data/baUndUnlc1/hic-arima2/41741_2%237.sub.cram', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'Undibacterium_unclassified/genomic_data/baUndUnlc1/hic-arima2/41741_2%237.sub.cram.crai', checkIfExists: true)
                 ]
                 input[1] = 10

--- a/subworkflows/sanger-tol/hic_mapping/main.nf
+++ b/subworkflows/sanger-tol/hic_mapping/main.nf
@@ -15,7 +15,6 @@ workflow HIC_MAPPING {
     ch_hic_cram          // Channel [meta, cram] OR [meta, [cram1, cram2, ..., cram_n]]
     val_aligner          // string: [either "bwamem2" or "minimap2"]
     val_cram_chunk_size  // integer: Number of CRAM slices per chunk for mapping
-    val_mark_duplicates  // boolean: Mark duplicates on the BAM?
 
     main:
     ch_versions = Channel.empty()
@@ -50,8 +49,11 @@ workflow HIC_MAPPING {
     // Module: Process the cram index files to determine how many
     //         chunks to split into for mapping
     //
+    ch_cram_indexes = ch_hic_cram_indexed
+        | map { meta, cram, index -> [ meta, index ] }
+
     CRAMALIGN_GENCRAMCHUNKS(
-        ch_hic_cram_indexed,
+        ch_cram_indexes,
         val_cram_chunk_size
     )
     ch_versions = ch_versions.mix(CRAMALIGN_GENCRAMCHUNKS.out.versions)
@@ -60,9 +62,16 @@ workflow HIC_MAPPING {
     // Logic: Count the total number of cram chunks for downstream grouping
     //
     ch_n_cram_chunks = CRAMALIGN_GENCRAMCHUNKS.out.cram_slices
-        | map { _meta, _cram, _crai, chunkn, _slices -> chunkn }
-        | collect
-        | map { chunkns -> chunkns.size() }
+        | map { meta, chunkn, _slices -> [ meta, chunkn ] }
+        | transpose()
+        | groupTuple(by: 0)
+        | map { meta, chunkns -> [ meta, chunkns.size() ] }
+
+    //
+    // Logic: Re-join the cram files and indexes to their chunk information
+    //
+    ch_cram_with_slices = ch_hic_cram_indexed
+        | combine(CRAMALIGN_GENCRAMCHUNKS.out.cram_slices, by: 0)
 
     //
     // Logic: Begin alignment - fork depending on specified aligner
@@ -77,12 +86,9 @@ workflow HIC_MAPPING {
         ch_assemblies_with_reference = ch_assemblies
             | combine(BWAMEM2_INDEX.out.index, by: 0)
 
-        ch_cram_chunks = CRAMALIGN_GENCRAMCHUNKS.out.cram_slices
+        ch_cram_chunks = ch_cram_with_slices
             | transpose()
-            | combine(ch_assemblies_with_reference)
-            | map { _meta, cram, crai, chunkn, slices, meta_assembly, index, assembly ->
-                [ meta_assembly, cram, crai, chunkn, slices, index, assembly ]
-            }
+            | combine(ch_assemblies_with_reference, by: 0)
 
         CRAMALIGN_BWAMEM2ALIGNHIC(ch_cram_chunks)
         ch_versions = ch_versions.mix(CRAMALIGN_BWAMEM2ALIGNHIC.out.versions)
@@ -95,12 +101,9 @@ workflow HIC_MAPPING {
         MINIMAP2_INDEX(ch_assemblies)
         ch_versions = ch_versions.mix(MINIMAP2_INDEX.out.versions)
 
-        ch_cram_chunks = CRAMALIGN_GENCRAMCHUNKS.out.cram_slices
+        ch_cram_chunks = ch_cram_with_slices
             | transpose()
-            | combine(MINIMAP2_INDEX.out.index)
-            | map { _meta, cram, crai, chunkn, slices, meta_assembly, index ->
-                [ meta_assembly, cram, crai, chunkn, slices, index ]
-            }
+            | combine(MINIMAP2_INDEX.out.index, by: 0)
 
         CRAMALIGN_MINIMAP2ALIGNHIC(ch_cram_chunks)
         ch_versions = ch_versions.mix(CRAMALIGN_MINIMAP2ALIGNHIC.out.versions)
@@ -111,14 +114,24 @@ workflow HIC_MAPPING {
     }
 
     //
-    // Logic: Index assembly fastas
+    // Module: Index assembly fastas
     //
     SAMTOOLS_FAIDX(
         ch_assemblies, // reference
-        [[:],[]],   // fai
-        false       // get sizes
+        [ [:],[] ],    // fai
+        false          // get sizes
     )
     ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
+
+    //
+    // Logic: create a channel with both fai and gzi for each assembly
+    //        We do it here so we don't cause downstream issues with the
+    //        remainder join
+    //
+    ch_fai_gzi = SAMTOOLS_FAIDX.out.fai
+        | join(SAMTOOLS_FAIDX.out.gzi, by: 0, remainder: true)
+        | map { meta, fai, gzi -> [ meta, fai, gzi ?: [] ] }
+
 
     //
     // Logic: Prepare input for merging bams.
@@ -126,21 +139,20 @@ workflow HIC_MAPPING {
     //        we emit groups downstream ASAP once all bams have been made
     //
     ch_samtools_merge_input = ch_mapped_bams
-        | combine(ch_n_cram_chunks)
+        | combine(ch_n_cram_chunks, by: 0)
         | map { meta, bam, n_chunks ->
             def key = groupKey(meta, n_chunks)
             [key, bam]
         }
-        | groupTuple()
+        | groupTuple(by: 0)
         | map { key, bam -> [key.target, bam] } // Get meta back out of groupKey
-        | join(ch_assemblies, by: 0)
-        | join(SAMTOOLS_FAIDX.out.fai, by: 0)
-        | join(SAMTOOLS_FAIDX.out.gzi, by: 0, remainder: true)
+        | combine(ch_assemblies, by: 0)
+        | combine(ch_fai_gzi, by: 0)
         | multiMap { meta, bams, assembly, fai, gzi ->
-            bam:   [meta, bams]
-            fasta: [meta, assembly]
-            fai:   [meta, fai]
-            gzi:   [meta, gzi ?: []]
+            bam:   [ meta, bams ]
+            fasta: [ meta, assembly ]
+            fai:   [ meta, fai ]
+            gzi:   [ meta, gzi ?: [] ]
         }
 
     //
@@ -158,11 +170,10 @@ workflow HIC_MAPPING {
     // Module: Mark duplicates on the merged bam
     //
     ch_samtools_markdup_input = SAMTOOLS_MERGE.out.bam
-        | filter { val_mark_duplicates }
         | combine(ch_assemblies, by: 0)
         | multiMap { meta, bam, assembly ->
-            bam:      [meta, bam]
-            assembly: [meta, assembly]
+            bam:      [ meta, bam ]
+            assembly: [ meta, assembly ]
         }
 
     SAMTOOLS_MARKDUP(
@@ -172,6 +183,6 @@ workflow HIC_MAPPING {
     ch_versions = ch_versions.mix(SAMTOOLS_MARKDUP.out.versions)
 
     emit:
-    bam      = val_mark_duplicates ? SAMTOOLS_MARKDUP.out.bam : SAMTOOLS_MERGE.out.bam
+    bam      = SAMTOOLS_MARKDUP.out.bam
     versions = ch_versions
 }

--- a/subworkflows/sanger-tol/hic_mapping/tests/main.nf.test
+++ b/subworkflows/sanger-tol/hic_mapping/tests/main.nf.test
@@ -34,7 +34,7 @@ nextflow_workflow {
         nfcoreLink("${launchDir}/library/", "${baseDir}/modules/")
     }
 
-    test("meles meles - bwamem2 - markdup") {
+    test("meles meles - bwamem2") {
 
         when {
 
@@ -51,7 +51,7 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of(
                     [
-                        [ id:'test', assembler: 'metamdbg' ], // meta map
+                        [ id:'test' ], // meta map
                         file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
                     ]
                 )
@@ -62,18 +62,18 @@ nextflow_workflow {
                     ]
                 )
                 input[2] = "bwamem2"
-                input[3] = 10
-                input[4] = true
+                input[3] = 1
                 """
             }
         }
 
         then {
             assertAll(
-                { assert workflow.success},
+                { assert workflow.success },
+                { assert workflow.out.bam.size() == 1 },
                 {
                     assert snapshot(
-                        bam(workflow.out.bam.get(0).get(1)).getReadsMD5(),
+                        //bam(workflow.out.bam.get(0).get(1)).getReadsMD5(),
                         workflow.out.versions
                     ).match()
                 }
@@ -85,7 +85,7 @@ nextflow_workflow {
         }
     }
 
-    test("meles meles - bwamem2 - no markdup") {
+    test("meles meles - bwamem2 - multiple samples") {
 
         when {
 
@@ -102,26 +102,34 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of(
                     [
-                        [ id:'test', assembler: 'metamdbg' ], // meta map
+                        [ id:'test' ], // meta map
+                        file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'test2' ], // meta map
                         file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
                     ]
                 )
                 input[1] = Channel.of(
                     [
                         [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'Meles_meles/genomic_data/mMelMel3/hic-arima2/35528_2%231_subset.cram', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'test2' ],
                         file(params.modules_testdata_base_path + 'Meles_meles/genomic_data/mMelMel3/hic-arima2/35528_2%231_subset.cram', checkIfExists: true)
                     ]
                 )
                 input[2] = "bwamem2"
-                input[3] = 10
-                input[4] = false
+                input[3] = 1
                 """
             }
         }
 
         then {
             assertAll(
-                { assert workflow.success},
+                { assert workflow.success },
+                { assert workflow.out.bam.size() == 2 },
                 {
                     assert snapshot(
                         bam(workflow.out.bam.get(0).get(1)).getReadsMD5(),
@@ -136,7 +144,66 @@ nextflow_workflow {
         }
     }
 
-    test("meles meles - minimap2 - markdup") {
+    test("meles meles - bwamem2 - multiple samples - meta mismatch") {
+
+        when {
+
+            params {
+                samtools_cat_args = ""
+                samtools_fastq_args = "-F0xB00 -nt"
+                bwamem2_mem_args = "-5SPp"
+                samtools_fixmate_args = "-mpu"
+                samtools_view_args = "-q 0 -F 0x904"
+                samtools_sort_args = "--write-index -l1"
+            }
+
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [
+                        [ id:'test' ], // meta map
+                        file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'test2' ], // meta map
+                        file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = Channel.of(
+                    [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'Meles_meles/genomic_data/mMelMel3/hic-arima2/35528_2%231_subset.cram', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'test3' ],
+                        file(params.modules_testdata_base_path + 'Meles_meles/genomic_data/mMelMel3/hic-arima2/35528_2%231_subset.cram', checkIfExists: true)
+                    ]
+                )
+                input[2] = "bwamem2"
+                input[3] = 1
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.bam.size() == 1 },
+                {
+                    assert snapshot(
+                        bam(workflow.out.bam.get(0).get(1)).getReadsMD5(),
+                        workflow.out.versions
+                    ).match()
+                }
+            )
+        }
+
+        cleanup {
+            nfcoreUnlink("${launchDir}/library/", "${baseDir}/modules/nf-core")
+        }
+    }
+
+    test("meles meles - minimap2") {
 
         when {
             params {
@@ -152,7 +219,7 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of(
                     [
-                        [ id:'test', assembler: 'metamdbg' ], // meta map
+                        [ id:'test' ], // meta map
                         file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
                     ]
                 )
@@ -163,65 +230,15 @@ nextflow_workflow {
                     ]
                 )
                 input[2] = "minimap2"
-                input[3] = 10
-                input[4] = true
+                input[3] = 1
                 """
             }
         }
 
         then {
             assertAll(
-                { assert workflow.success},
-                {
-                    assert snapshot(
-                        bam(workflow.out.bam.get(0).get(1)).getReadsMD5(),
-                        workflow.out.versions
-                    ).match()
-                }
-            )
-        }
-
-        cleanup {
-            nfcoreUnlink("${launchDir}/library/", "${baseDir}/modules/nf-core")
-        }
-    }
-
-    test("meles meles - minimap2 - no markdup") {
-
-        when {
-            params {
-                samtools_cat_args     = ""
-                samtools_fastq_args   = "-F0xB00 -nt"
-                minimap2_args         = "-ax sr"
-                samtools_fixmate_args = "-mpu"
-                samtools_view_args    = "-q 0 -F 0x904"
-                samtools_sort_args    = "--write-index -l1"
-            }
-
-            workflow {
-                """
-                input[0] = Channel.of(
-                    [
-                        [ id:'test', assembler: 'metamdbg' ], // meta map
-                        file(params.modules_testdata_base_path + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta.gz', checkIfExists: true)
-                    ]
-                )
-                input[1] = Channel.of(
-                    [
-                        [ id:'test' ],
-                        file(params.modules_testdata_base_path + 'Meles_meles/genomic_data/mMelMel3/hic-arima2/35528_2%231_subset.cram', checkIfExists: true)
-                    ]
-                )
-                input[2] = "minimap2"
-                input[3] = 10
-                input[4] = false
-                """
-            }
-        }
-
-        then {
-            assertAll(
-                { assert workflow.success},
+                { assert workflow.success },
+                { assert workflow.out.bam.size() == 1 },
                 {
                     assert snapshot(
                         bam(workflow.out.bam.get(0).get(1)).getReadsMD5(),

--- a/subworkflows/sanger-tol/hic_mapping/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/hic_mapping/tests/main.nf.test.snap
@@ -1,8 +1,54 @@
 {
-    "meles meles - minimap2 - no markdup": {
+    "meles meles - bwamem2 - multiple samples": {
+        "content": [
+            "18a7b1230848a060219df7ddf5c78f25",
+            [
+                "versions.yml:md5,6da1ff684dd357b0be447eff01112c09",
+                "versions.yml:md5,6da1ff684dd357b0be447eff01112c09",
+                "versions.yml:md5,804d2da0c4ff5dfe1ea5b14f0c3994a2",
+                "versions.yml:md5,804d2da0c4ff5dfe1ea5b14f0c3994a2",
+                "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
+                "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
+                "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
+                "versions.yml:md5,fdcbb8a03dee4c8ba03fd83bbcd10f19",
+                "versions.yml:md5,fdcbb8a03dee4c8ba03fd83bbcd10f19"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-10-03T12:26:28.87123"
+    },
+    "meles meles - bwamem2": {
+        "content": [
+            [
+                "versions.yml:md5,6da1ff684dd357b0be447eff01112c09",
+                "versions.yml:md5,804d2da0c4ff5dfe1ea5b14f0c3994a2",
+                "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
+                "versions.yml:md5,fdcbb8a03dee4c8ba03fd83bbcd10f19"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-10-03T13:05:30.47784"
+    },
+    "meles meles - minimap2": {
         "content": [
             "3196a1997c55d543d773a1af0595fa6d",
             [
+                "versions.yml:md5,6da1ff684dd357b0be447eff01112c09",
+                "versions.yml:md5,897099b3ba1f2612a98b07f805a89d42",
                 "versions.yml:md5,897099b3ba1f2612a98b07f805a89d42",
                 "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
                 "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
@@ -14,51 +60,20 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-10-03T10:06:26.031366"
+        "timestamp": "2025-10-03T13:08:54.568952"
     },
-    "meles meles - bwamem2 - no markdup": {
+    "meles meles - bwamem2 - multiple samples - meta mismatch": {
         "content": [
-            "12bbc3437515580a7dcc3c0d677c225a",
-            [
-                "versions.yml:md5,804d2da0c4ff5dfe1ea5b14f0c3994a2",
-                "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
-                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
-                "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
-                "versions.yml:md5,fdcbb8a03dee4c8ba03fd83bbcd10f19"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-10-03T10:04:33.173585"
-    },
-    "meles meles - minimap2 - markdup": {
-        "content": [
-            "3196a1997c55d543d773a1af0595fa6d",
-            [
-                "versions.yml:md5,6da1ff684dd357b0be447eff01112c09",
-                "versions.yml:md5,897099b3ba1f2612a98b07f805a89d42",
-                "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
-                "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
-                "versions.yml:md5,fd15db333caf07479a96afdbe9a149e0",
-                "versions.yml:md5,fdcbb8a03dee4c8ba03fd83bbcd10f19"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-10-03T10:05:32.385702"
-    },
-    "meles meles - bwamem2 - markdup": {
-        "content": [
-            "12bbc3437515580a7dcc3c0d677c225a",
+            "18a7b1230848a060219df7ddf5c78f25",
             [
                 "versions.yml:md5,6da1ff684dd357b0be447eff01112c09",
                 "versions.yml:md5,804d2da0c4ff5dfe1ea5b14f0c3994a2",
+                "versions.yml:md5,804d2da0c4ff5dfe1ea5b14f0c3994a2",
+                "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
                 "versions.yml:md5,937b65ae8a1a62094e422deed4aa2480",
                 "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,bbc059343be8756eb41864dceae346d0",
+                "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
                 "versions.yml:md5,e938bc5e520e0423caa5e6ed7908cb3d",
                 "versions.yml:md5,fdcbb8a03dee4c8ba03fd83bbcd10f19"
             ]
@@ -67,6 +82,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-10-03T10:03:30.563195"
+        "timestamp": "2025-10-03T13:07:50.723861"
     }
 }


### PR DESCRIPTION
This PR changes the Hi-C mapping subworkflow so that it matches assemblies and CRAM files on the meta object. Thus, you get one output BAM file per /matching/ input meta between the two (this means it is incumbent on the host pipeline to stage metas correctly). Assemblies/CRAMS with mismatching metas simply will not produce a BAM.

After discussion, I have also dropped the optional markdup option - all BAMs get markduped now.

It also modifies the cramalign/gencramchunks process to drop the unnecessary inputs/outputs to reduce the chances of resume bugs.

## PR checklist

Closes #72 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
