### PR TITLE
Reenable CI sharding

### DIFF
--- a/.github/actions/get-shards/action.yml
+++ b/.github/actions/get-shards/action.yml
@@ -4,9 +4,19 @@ inputs:
   tags:
     description: "Tags to pass as argument for nf-test --tag parameter"
     required: true
+  max_shards:
+    description: "Maximum number of shards allowed"
+    required: true
   paths:
     description: "Component paths to test"
     required: false
+outputs:
+  shard:
+    description: "Array of shard numbers"
+    value: ${{ steps.shards.outputs.shard }}
+  total_shards:
+    description: "Total number of shards"
+    value: ${{ steps.shards.outputs.total_shards }}
 runs:
   using: "composite"
   steps:
@@ -15,3 +25,49 @@ runs:
       with:
         version: ${{ env.NFT_VER }}
         install-pdiff: true
+    - name: Get number of shards
+      id: shards
+      shell: bash
+      run: |
+        # Prepare tag parameter if tags are provided
+        TAGS=$([ -n "${{ inputs.tags }}" ] && echo "--tag ${{ inputs.tags }}" || echo "")
+
+        # Run nf-test with dynamic parameter
+        nftest_output=$(nf-test test \
+          --dry-run \
+          --profile docker \
+          ${TAGS} \
+          --filter process,workflow \
+          ${{ inputs.paths }}) || {
+            echo "nf-test command failed with exit code $?"
+            echo "Full output: $nftest_output"
+            exit 1
+        }
+        echo "nf-test dry-run output: $nftest_output"
+
+        # Default values for shard and total_shards
+        shard="[]"
+        total_shards=0
+
+        # Check if there are related tests
+        if echo "$nftest_output" | grep -q 'No tests to execute'; then
+          echo "No related tests found."
+        else
+          # Extract the number of related tests
+          number_of_shards=$(echo "$nftest_output" | sed -n 's|.*Executed \([0-9]*\) tests.*|\1|p')
+          if [[ -n "$number_of_shards" && "$number_of_shards" -gt 0 ]]; then
+            shards_to_run=$(( $number_of_shards < ${{ inputs.max_shards }} ? $number_of_shards : ${{ inputs.max_shards }} ))
+            shard=$(seq 1 "$shards_to_run" | jq -R . | jq -c -s .)
+            total_shards="$shards_to_run"
+          else
+            echo "Unexpected output format. Falling back to default values."
+          fi
+        fi
+
+        # Write to GitHub Actions outputs
+        echo "shard=$shard" >> $GITHUB_OUTPUT
+        echo "total_shards=$total_shards" >> $GITHUB_OUTPUT
+
+        # Debugging output
+        echo "Final shard array: $shard"
+        echo "Total number of shards: $total_shards"

--- a/.github/actions/nf-test-action/action.yml
+++ b/.github/actions/nf-test-action/action.yml
@@ -4,6 +4,12 @@ inputs:
   profile:
     description: "Profile to use"
     required: true
+  shard:
+    description: "Shard number for this CI job"
+    required: true
+  total_shards:
+    description: "Total number of test shards(NOT the total number of matrix jobs)"
+    required: true
   paths:
     description: "Test paths"
     required: true
@@ -86,6 +92,7 @@ runs:
           --tap=test.tap \
           --verbose \
           --ci \
+          --shard ${{ inputs.shard }}/${{ inputs.total_shards }} \
           --filter process,workflow \
           ${{ inputs.paths }}
 
@@ -111,16 +118,16 @@ runs:
               test_name="${line#ok }"
               # Remove the test number from the beginning
               test_name="${test_name#* }"
-              echo "| ✅ | ${test_name} | ${{ inputs.profile }} |" >> $GITHUB_STEP_SUMMARY
+              echo "| ✅ | ${test_name} | ${{ inputs.profile }} | ${{ inputs.shard }}/${{ inputs.total_shards }} |" >> $GITHUB_STEP_SUMMARY
             elif [[ $line =~ ^not\ ok ]]; then
               test_name="${line#not ok }"
               # Remove the test number from the beginning
               test_name="${test_name#* }"
-              echo "| ❌ | ${test_name} | ${{ inputs.profile }} |" >> $GITHUB_STEP_SUMMARY
+              echo "| ❌ | ${test_name} | ${{ inputs.profile }} | ${{ inputs.shard }}/${{ inputs.total_shards }} |" >> $GITHUB_STEP_SUMMARY
             fi
           done < test.tap
         else
-          echo "| ⚠️ | No test results found | ${{ inputs.profile }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ⚠️ | No test results found | ${{ inputs.profile }} | ${{ inputs.shard }}/${{ inputs.total_shards }} |" >> $GITHUB_STEP_SUMMARY
         fi
 
     - name: Clean up

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -36,6 +36,8 @@ jobs:
       paths: ${{ steps.list.outputs.components }}
       modules: ${{ steps.components.outputs.modules }}
       subworkflows: ${{ steps.components.outputs.subworkflows}}
+      shard: ${{ steps.set-shards.outputs.shard }}
+      total_shards: ${{ steps.set-shards.outputs.total_shards }}
     steps:
       - name: Clean Workspace # Purge the workspace in case it's running on a self-hosted runner
         run: |
@@ -69,6 +71,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
+          max_shards: 15
           paths: "${{ join(fromJson(steps.list.outputs.components ), ' ') }}"
 
       - name: debug
@@ -76,14 +79,18 @@ jobs:
           echo ${{ steps.list.outputs.components }}
           echo ${{ steps.components.outputs.modules }}
           echo ${{ steps.components.outputs.subworkflows }}
+          echo ${{ steps.set-shards.outputs.shard }}
+          echo ${{ steps.set-shards.outputs.total_shards }}
 
   nf-test:
     runs-on: ubuntu-latest
-    name: "${{ matrix.arch }} | ${{ matrix.profile }}"
+    name: "${{ matrix.arch }} | ${{ matrix.profile }} | ${{ matrix.shard }}"
     needs: [nf-test-changes]
+    if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
     strategy:
       fail-fast: false
       matrix:
+        shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
         profile: [conda, docker, singularity]
         arch:
           - x64
@@ -91,6 +98,7 @@ jobs:
           # - arm64
     env:
       NXF_ANSI_LOG: false
+      TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
     outputs:
       filtered_paths: ${{ steps.filter.outputs.filtered_paths }}
 
@@ -150,6 +158,8 @@ jobs:
           SENTIEON_AUTH_MECH: "GitHub Actions - token"
         with:
           profile: ${{ matrix.profile }}${{ runner.arch == 'ARM64' && ',arm64,wave' || '' }}
+          shard: ${{ matrix.shard }}
+          total_shards: ${{ env.TOTAL_SHARDS }}
           paths: "${{ join(fromJson(steps.filter.outputs.filtered_paths), ' ') }}"
 
   confirm-pass-nf-test:

--- a/nf-test.config
+++ b/nf-test.config
@@ -15,6 +15,6 @@ config {
     plugins {
         load "nft-bam@0.6.0"
         load "nft-vcf@1.0.7"
-        load "nft-utils@0.0.5"
+        load "nft-utils@0.0.7"
     }
 }


### PR DESCRIPTION
Demo in #89 

This is simply reverting #79 and bumping up the nft-utils version.

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
