### PR TITLE
feat(fastx_map_long_reads): group output paf files

### DIFF
--- a/subworkflows/sanger-tol/fastx_map_long_reads/main.nf
+++ b/subworkflows/sanger-tol/fastx_map_long_reads/main.nf
@@ -79,7 +79,7 @@ workflow FASTX_MAP_LONG_READS {
             def key = groupKey(meta, n_chunks)
             [key, paf]
         }
-        | groupTuple(by: 0)
+        | groupTuple(by: 0, sort: { it.getName() } )
         | map { key, paf -> [key.target, paf] } // Get meta back out of groupKey
 
     //

--- a/subworkflows/sanger-tol/fastx_map_long_reads/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/fastx_map_long_reads/tests/main.nf.test.snap
@@ -41,10 +41,10 @@
                     },
                     [
                         "HiFi.reads.fasta.0.test.paf.gz:md5,d74ffe5ca051a58b834712bbfecb7875",
-                        "HiFi.reads.fasta.4.test.paf.gz:md5,ee7fdba4b0311d309292f28ada0ef137",
-                        "HiFi.reads.fasta.3.test.paf.gz:md5,7f945c1697a0e727c672bffe0dab8799",
+                        "HiFi.reads.fasta.1.test.paf.gz:md5,b534510e942d0b8ea7150bb08a0ac9e1",
                         "HiFi.reads.fasta.2.test.paf.gz:md5,ba98f31b846d1830279c51d3bc829760",
-                        "HiFi.reads.fasta.1.test.paf.gz:md5,b534510e942d0b8ea7150bb08a0ac9e1"
+                        "HiFi.reads.fasta.3.test.paf.gz:md5,7f945c1697a0e727c672bffe0dab8799",
+                        "HiFi.reads.fasta.4.test.paf.gz:md5,ee7fdba4b0311d309292f28ada0ef137"
                     ]
                 ]
             ],
@@ -62,6 +62,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-10-28T17:08:29.448759"
+        "timestamp": "2025-10-29T09:16:47.78948"
     }
 }


### PR DESCRIPTION
Group output PAF files by `meta` prior to emission from the subworkflow. This allows us to use the groupKey we made for grouping.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
