### PR TITLE
Option to extract columns from the TSV before compressing and indexing it

### DIFF
--- a/modules/sanger-tol/bgziptabix/main.nf
+++ b/modules/sanger-tol/bgziptabix/main.nf
@@ -24,18 +24,20 @@ process BGZIPTABIX {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = input.extension
     """
-    bgzip --threads ${task.cpus} --index ${args} ${input} --output ${prefix}.${input.extension}.gz
-    [[ ${max_seq_length} -lt \$(( 2 ** 29 )) ]] && tabix --threads ${task.cpus} ${args2} ${prefix}.${input.extension}.gz
-    [[ ${max_seq_length} -lt \$(( 2 ** 32 )) ]] && tabix --threads ${task.cpus} --csi ${args2} ${prefix}.${input.extension}.gz
+    bgzip --threads ${task.cpus} --index ${args} ${input} --output ${prefix}.${extension}.gz
+    [[ ${max_seq_length} -lt \$(( 2 ** 29 )) ]] && tabix --threads ${task.cpus} ${args2} ${prefix}.${extension}.gz
+    [[ ${max_seq_length} -lt \$(( 2 ** 32 )) ]] && tabix --threads ${task.cpus} --csi ${args2} ${prefix}.${extension}.gz
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = input.extension
     """
-    echo "" | gzip > ${prefix}.${input.extension}.gz
-    touch ${prefix}.${input.extension}.gz.gzi
-    touch ${prefix}.${input.extension}.gz.tbi
-    touch ${prefix}.${input.extension}.gz.csi
+    echo "" | gzip > ${prefix}.${extension}.gz
+    touch ${prefix}.${extension}.gz.gzi
+    touch ${prefix}.${extension}.gz.tbi
+    touch ${prefix}.${extension}.gz.csi
     """
 }

--- a/modules/sanger-tol/bgziptabix/main.nf
+++ b/modules/sanger-tol/bgziptabix/main.nf
@@ -25,7 +25,7 @@ process BGZIPTABIX {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input_data = column_numbers ? "<(cut -f${column_numbers} ${input} | tail -n+${header_lines+1})" : input
+    def input_data = column_numbers ? "<(cut -f${column_numbers} ${input} | tail -n+${header_lines + 1})" : input
     extension ?= input.extension
     """
     bgzip --threads ${task.cpus} --index ${args} ${input_data} --output ${prefix}.${extension}.gz

--- a/modules/sanger-tol/bgziptabix/main.nf
+++ b/modules/sanger-tol/bgziptabix/main.nf
@@ -9,6 +9,7 @@ process BGZIPTABIX {
 
     input:
     tuple val(meta), path(input), val(max_seq_length)
+    tuple val(column_numbers), val(header_lines), val(extension)
 
     output:
     tuple val(meta), path("*.gz"), path("*.gzi"), emit: gz_index
@@ -24,16 +25,17 @@ process BGZIPTABIX {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def extension = input.extension
+    def input_data = column_numbers ? "<(cut -f${column_numbers} ${input} | tail -n+${header_lines+1})" : input
+    extension ?= input.extension
     """
-    bgzip --threads ${task.cpus} --index ${args} ${input} --output ${prefix}.${extension}.gz
+    bgzip --threads ${task.cpus} --index ${args} ${input_data} --output ${prefix}.${extension}.gz
     [[ ${max_seq_length} -lt \$(( 2 ** 29 )) ]] && tabix --threads ${task.cpus} ${args2} ${prefix}.${extension}.gz
     [[ ${max_seq_length} -lt \$(( 2 ** 32 )) ]] && tabix --threads ${task.cpus} --csi ${args2} ${prefix}.${extension}.gz
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def extension = input.extension
+    extension ?= input.extension
     """
     echo "" | gzip > ${prefix}.${extension}.gz
     touch ${prefix}.${extension}.gz.gzi

--- a/modules/sanger-tol/bgziptabix/meta.yml
+++ b/modules/sanger-tol/bgziptabix/meta.yml
@@ -41,11 +41,12 @@ input:
   - - column_numbers:
         type: string
         description: |
-          Columns to extract from the input file, in a format understood by `cut`
+          Optional. Columns to extract from the input file, in a format understood by `cut`
           e.g. '1-3,5'
     - header_lines:
         type: integer
-        description: Number of header lines to skip from the input file
+        description: |
+          Number of header lines to skip from the input file. Only considered when column_numbers
     - extension:
         type: string
         description: |

--- a/modules/sanger-tol/bgziptabix/meta.yml
+++ b/modules/sanger-tol/bgziptabix/meta.yml
@@ -38,7 +38,19 @@ input:
     - max_seq_length:
         type: integer
         description: Maximum length (coordinate) of a sequence in this genome (TSV)
-        ontologies: []
+  - - column_numbers:
+        type: string
+        description: |
+          Columns to extract from the input file, in a format understood by `cut`
+          e.g. '1-3,5'
+    - header_lines:
+        type: integer
+        description: Number of header lines to skip from the input file
+    - extension:
+        type: string
+        description: |
+          Extension to name the output file, in case it differs from the input
+          file - for instance, turning a TSV into BED
 output:
   gz_index:
     - - meta:

--- a/modules/sanger-tol/bgziptabix/tests/main.nf.test
+++ b/modules/sanger-tol/bgziptabix/tests/main.nf.test
@@ -19,6 +19,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bed', checkIfExists: true),
                     60000,
                 ])
+                input[1] = ["", "", ""]
                 """
             }
         }
@@ -40,6 +41,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bed', checkIfExists: true),
                     2**30,
                 ])
+                input[1] = ["", "", ""]
                 """
             }
         }
@@ -50,7 +52,6 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
-
     }
 
     test("bed with extra long sequences (no index possible)") {
@@ -63,6 +64,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bed', checkIfExists: true),
                     2**34,
                 ])
+                input[1] = ["", "", ""]
                 """
             }
         }
@@ -73,7 +75,28 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
+    }
 
+    test("tsv to bed") {
+        when {
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.nfcore_modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.annotated_intervals.tsv', checkIfExists: true),
+                    60000,
+                ])
+                input[1] = ["1-3", 3, "bed"]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
     }
 
     test("stub") {
@@ -87,6 +110,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bed', checkIfExists: true),
                     60000,
                 ])
+                input[1] = ["", "", ""]
                 """
             }
         }
@@ -97,7 +121,6 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
-
     }
 
 }

--- a/modules/sanger-tol/bgziptabix/tests/main.nf.test.snap
+++ b/modules/sanger-tol/bgziptabix/tests/main.nf.test.snap
@@ -1,4 +1,93 @@
 {
+    "tsv to bed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed.gz:md5,1280050828c9d0401871239fb267a63f",
+                        "test.bed.gz.gzi:md5,7dea362b3fac8e00956a4952a3d4f474"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed.gz.tbi:md5,8fc7bc9e739aacaed7a26d7bf56844d2"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed.gz.csi:md5,8d36d8571b898909ff148b75ceae0f76"
+                    ]
+                ],
+                "3": [
+                    [
+                        "BGZIPTABIX",
+                        "bgzip",
+                        "1.21"
+                    ]
+                ],
+                "4": [
+                    [
+                        "BGZIPTABIX",
+                        "tabix",
+                        "1.21"
+                    ]
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed.gz.csi:md5,8d36d8571b898909ff148b75ceae0f76"
+                    ]
+                ],
+                "gz_index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed.gz:md5,1280050828c9d0401871239fb267a63f",
+                        "test.bed.gz.gzi:md5,7dea362b3fac8e00956a4952a3d4f474"
+                    ]
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed.gz.tbi:md5,8fc7bc9e739aacaed7a26d7bf56844d2"
+                    ]
+                ],
+                "versions_bgzip": [
+                    [
+                        "BGZIPTABIX",
+                        "bgzip",
+                        "1.21"
+                    ]
+                ],
+                "versions_tabix": [
+                    [
+                        "BGZIPTABIX",
+                        "tabix",
+                        "1.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-04T10:58:07.794595226"
+    },
     "stub": {
         "content": [
             {

--- a/subworkflows/sanger-tol/soft_masked_fasta_repeats/main.nf
+++ b/subworkflows/sanger-tol/soft_masked_fasta_repeats/main.nf
@@ -18,7 +18,7 @@ workflow SOFT_MASKED_FASTA_REPEATS {
     ch_bed_with_seq_length = ch_bed
         .join(ch_fasta_sequence_length)
         .map { meta, bed, _fasta, max_seq_length -> [meta, bed, max_seq_length] }
-    BGZIPTABIX(ch_bed_with_seq_length)
+    BGZIPTABIX(ch_bed_with_seq_length, ["", "", ""])
 
     ch_repeats = BGZIPTABIX.out.gz_index
         .join(BGZIPTABIX.out.tbi, by: 0, remainder: true)


### PR DESCRIPTION
A PR to address https://github.com/sanger-tol/sequencecomposition/pull/47#discussion_r2878291556

Jim made me realise that there's no need to have the patch in my pipeline since the module is from sanger-tol.

This adds optional parameters in BGZIPTABIX to `cut` certain columns and skip some header lines from the TSV, as well as updating the extension.

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] If you've added or modified a sub-workflow, ensure all sub-analyses are emitted as individual channels. Outputs may also be collected together by analysis type or input sample, for instance to support downstream analysis or publishing.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
