### PR TITLE
Update to use bioawk

### DIFF
--- a/subworkflows/sanger-tol/telo_finder/main.nf
+++ b/subworkflows/sanger-tol/telo_finder/main.nf
@@ -1,6 +1,7 @@
 //
 // MODULE IMPORT BLOCK
 //
+include { BIOAWK                        } from '../../../modules/nf-core/bioawk/main'
 include { TELOMERE_REGIONS              } from '../../../modules/sanger-tol/telomere/regions/main'
 include { GAWK as GAWK_SPLIT_TELOMERE   } from '../../../modules/nf-core/gawk/main'
 include { TELOMERE_WINDOWS              } from '../../../modules/sanger-tol/telomere/windows/main'
@@ -12,20 +13,42 @@ workflow TELO_FINDER {
 
     take:
     ch_reference        // Channel [ val(meta), path(fasta) ]
-    ch_telomereseq      // Channel.of( telomere sequence )
+    ch_telomereseq      // Channel [ val(meta), path(fasta) ]
     val_split_telomere  // bool
     val_run_bgzip       // bool
 
     main:
 
-    //if G > 30% then flip else pass
+    //
+    // MODULE: BIOAWK CONVERT THE MOTIF INTO THE 5 PRIME DIRECTION
+    //         IF PROVIDED IN THE 3 PRIME DIRECTION
+    //         IF MOTIF HAS A G CONTENT OF > 30% IT IS IN THE 3 PRIME
+    //
+    BIOAWK(
+        ch_telomereseq,
+        "tsv"
+    )
+
+
+    //
+    // LOGIC: READ LINE 2 OF THE OUTPUT FILE
+    //
+    corrected_telomere = BIOAWK.out.output
+        .map { _meta, file ->
+            def lines = file.toFile().readLines()
+            // Lines from bioawk are:
+            // corrected_sequence  G_count  G_percentage  reversed?  original_sequence
+            lines[0].split('\t')[0]
+        }
+        .filter { it != null }
+
 
     //
     // MODULE: FINDS THE TELOMERIC SEQEUNCE IN REFERENCE
     //
     TELOMERE_REGIONS (
         ch_reference,
-        ch_telomereseq
+        corrected_telomere
     )
 
     ch_full_telomere = TELOMERE_REGIONS.out.telomere
@@ -89,7 +112,7 @@ workflow TELO_FINDER {
     //         THIS ONLY HAPPENS ON WHOLE TELOMERIC FILES
     //
     TELOMERE_WINDOWS (
-        ch_regions_for_extraction.filter { meta, file -> meta.direction == 0 }
+        ch_regions_for_extraction.filter { meta, _file -> meta.direction == 0 }
     )
 
     //
@@ -140,8 +163,9 @@ workflow TELO_FINDER {
     )
 
     emit:
-    bed_file        = ch_telo_bedfiles          // Channel [meta, bed]
-    bed_gz_tbi      = TABIX_BGZIPTABIX.out.gz_index  // Not used anymore
-    bedgraph_file   = ch_telo_bedgraphs         // Channel [meta, [bedfiles]] - Used in pretext_graph
+    telomere_summary    = BIOAWK.out.output             // Channel [meta, tsv]
+    bed_file            = ch_telo_bedfiles              // Channel [meta, bed]
+    bed_gz_tbi          = TABIX_BGZIPTABIX.out.gz_index // Channel [meta, index]
+    bedgraph_file       = ch_telo_bedgraphs             // Channel [meta, [bedfiles]] - Used in pretext_graph
 
 }

--- a/subworkflows/sanger-tol/telo_finder/main.nf
+++ b/subworkflows/sanger-tol/telo_finder/main.nf
@@ -31,31 +31,43 @@ workflow TELO_FINDER {
 
 
     //
-    // LOGIC: READ LINE 2 OF THE OUTPUT FILE
+    // LOGIC: READ LINES OF THE OUTPUT FILE
+    //        RETURN THE FIRST SEGMENT OF LINE
+    //        LINE IS EQUAL TO:
+    //        corrected_sequence  G_count  G_percentage  reversed?  original_sequence
     //
-    corrected_telomere = BIOAWK.out.output
-        .map { _meta, file ->
+    ch_corrected_telomere = BIOAWK.out.output
+        .map { meta, file ->
             def lines = file.toFile().readLines()
-            // Lines from bioawk are:
-            // corrected_sequence  G_count  G_percentage  reversed?  original_sequence
-            lines[0].split('\t')[0]
+            tuple(meta, lines[0].split('\t')[0])
         }
-        .filter { it != null }
+
+
+    // NOTE: COMBINE CHANNELS TO ENSURE TELOMERE IS FOR X REFERENCE
+    matched_channels = ch_reference
+        .combine(ch_corrected_telomere)
+        .multiMap { meta, ref, telomere ->
+            reference_ch: [meta, ref]
+            telomere_ch: telomere
+        }
 
 
     //
     // MODULE: FINDS THE TELOMERIC SEQEUNCE IN REFERENCE
     //
     TELOMERE_REGIONS (
-        ch_reference,
-        corrected_telomere
+        matched_channels.reference_ch,
+        matched_channels.telomere_ch
     )
 
+
+    // NOTE: TAG THE DIRECTION OF THE TELOMERE AS 0 == WHOLE DATASET
     ch_full_telomere = TELOMERE_REGIONS.out.telomere
         .map{ meta, file ->
             def new_meta = meta + [direction: 0]
             [new_meta, file]
         }
+
 
     //
     // MODULE: SPLIT THE TELOMERE FILE INTO 5' and 3' FILES

--- a/subworkflows/sanger-tol/telo_finder/main.nf
+++ b/subworkflows/sanger-tol/telo_finder/main.nf
@@ -19,6 +19,22 @@ workflow TELO_FINDER {
 
     main:
 
+    // NOTE: BIOAWK PROGRAM TO RETURN A TAB DELIMITED FILE CONTAINING:
+    //       corrected_sequence  G_count  G_percentage  reversed?  original_sequence
+    ch_bioawk_program = channel.of('''\
+        BEGIN { OFS = "\\t" } {
+            sequence = toupper($seq);
+            copy_seq = sequence;
+            g_count = gsub(/G/, "", sequence);
+            g_percent = 100*g_count/length(copy_seq);
+            rev = (g_percent > 30);
+            final_sequence = rev ? revcomp($seq) : $seq;
+            printf "%s\\t%d\\t%.2f\\t%s\\t%s\\n", final_sequence, g_count, g_percent, (rev ? "true" : "false"), copy_seq
+        }'''.stripIndent())
+        .collectFile(name: "bioawk_getdata.awk", cache: true)
+        .collect()
+
+
     //
     // MODULE: BIOAWK CONVERT THE MOTIF INTO THE 5 PRIME DIRECTION
     //         IF PROVIDED IN THE 3 PRIME DIRECTION
@@ -26,15 +42,15 @@ workflow TELO_FINDER {
     //
     BIOAWK(
         ch_telomereseq,
+        ch_bioawk_program,
+        false,
         "tsv"
     )
 
 
     //
     // LOGIC: READ LINES OF THE OUTPUT FILE
-    //        RETURN THE FIRST SEGMENT OF LINE
-    //        LINE IS EQUAL TO:
-    //        corrected_sequence  G_count  G_percentage  reversed?  original_sequence
+    //        RETURN THE FIRST SEGMENT OF LINE "corrected_sequence"
     //
     ch_corrected_telomere = BIOAWK.out.output
         .map { meta, file ->
@@ -45,7 +61,7 @@ workflow TELO_FINDER {
 
     // NOTE: COMBINE CHANNELS TO ENSURE TELOMERE IS FOR X REFERENCE
     matched_channels = ch_reference
-        .combine(ch_corrected_telomere)
+        .combine(ch_corrected_telomere, by: 0)
         .multiMap { meta, ref, telomere ->
             reference_ch: [meta, ref]
             telomere_ch: telomere
@@ -88,6 +104,7 @@ workflow TELO_FINDER {
             ch_split_telomere,
             true
         )
+
 
         //
         // LOGIC: COLLECT FILES AND ITERATE THROUGH

--- a/subworkflows/sanger-tol/telo_finder/meta.yml
+++ b/subworkflows/sanger-tol/telo_finder/meta.yml
@@ -29,7 +29,7 @@ input:
       description: |
         Structure [ val(meta), path(telomere_motif) ]
         Meta is the Groovy Map containing sample information
-        A string containing the DNA sequence of a telomere motif
+        A fasta formatted file containing the DNA sequence of a telomere motif
   - val_split_telomere:
       type: boolean
       description: |

--- a/subworkflows/sanger-tol/telo_finder/meta.yml
+++ b/subworkflows/sanger-tol/telo_finder/meta.yml
@@ -27,7 +27,7 @@ input:
   - ch_telomereseq:
       type: file
       description: |
-        Structure [ val(meta), path(reference) ]
+        Structure [ val(meta), path(telomere_motif) ]
         Meta is the Groovy Map containing sample information
         A string containing the DNA sequence of a telomere motif
   - val_split_telomere:

--- a/subworkflows/sanger-tol/telo_finder/meta.yml
+++ b/subworkflows/sanger-tol/telo_finder/meta.yml
@@ -11,6 +11,8 @@ components:
   - telomere/regions
   - telomere/windows
   - telomere/extract
+  - bioawk:
+      git_remote: https://github.com/nf-core/modules.git
   - gawk:
       git_remote: https://github.com/nf-core/modules.git
   - tabix/bgziptabix:
@@ -23,8 +25,10 @@ input:
         Meta is the Groovy Map containing sample information
         Reference is the fasta for analysis
   - ch_telomereseq:
-      type: string
+      type: file
       description: |
+        Structure [ val(meta), path(reference) ]
+        Meta is the Groovy Map containing sample information
         A string containing the DNA sequence of a telomere motif
   - val_split_telomere:
       type: boolean
@@ -35,6 +39,11 @@ input:
       description: |
         Control running of tabix with boolean
 output:
+  - telomere_summary:
+      type: file
+      description: |
+        Structure: [ val(meta), path(tsv) ]
+        A tsv file summarising the telomere regions found.
   - bed_file:
       type: file
       description: |

--- a/subworkflows/sanger-tol/telo_finder/nextflow.config
+++ b/subworkflows/sanger-tol/telo_finder/nextflow.config
@@ -3,7 +3,7 @@ nextflow.enable.moduleBinaries = true
 process {
 
     withName: BIOAWK {
-        ext.args = { "-c fastx \'{s = toupper($seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct < 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\t%d\t%.2f\t%s\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'" }
+        ext.args = { "-c fastx" }
     }
 
     withName: TELOMERE_WINDOWS {

--- a/subworkflows/sanger-tol/telo_finder/nextflow.config
+++ b/subworkflows/sanger-tol/telo_finder/nextflow.config
@@ -1,6 +1,11 @@
 nextflow.enable.moduleBinaries = true
 
 process {
+
+    withName: BIOAWK {
+        ext.args = { "-c fastx \'{s = toupper($seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct < 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\t%d\t%.2f\t%s\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'" }
+    }
+
     withName: TELOMERE_WINDOWS {
         tag         = { "${meta.id}_${meta.direction}P" }
         ext.args    = "99.9"

--- a/subworkflows/sanger-tol/telo_finder/tests/main.nf.test
+++ b/subworkflows/sanger-tol/telo_finder/tests/main.nf.test
@@ -12,10 +12,12 @@ nextflow_workflow {
     tag "telomere/windows"
     tag "telomere/extract"
     tag "tabix/bgziptabix"
+    tag "subworkflows/../../modules/nf-core/bioawk"
     tag "subworkflows/../../modules/nf-core/gawk"
     tag "subworkflows/../../modules/nf-core/gunzip"
     tag "subworkflows/../../modules/nf-core/tabix/bgziptabix"
     tag "modules/nf-core/gunzip"
+    tag "modules/nf-core/bioawk"
 
     setup {
         nfcoreInitialise("${launchDir}/library/")
@@ -24,7 +26,8 @@ nextflow_workflow {
             [
                 "gawk",
                 "tabix/bgziptabix",
-                "gunzip"
+                "gunzip",
+                "bioawk"
             ]
         )
         nfcoreLink("${launchDir}/library/", "${baseDir}/modules/")
@@ -46,6 +49,7 @@ nextflow_workflow {
     test("idFanCani4 - no split - fasta w/ index") {
         when {
             params {
+                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -53,7 +57,10 @@ nextflow_workflow {
             workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
-                input[1] = "TTAGG"
+                input[1] = [
+                    [ id: "motifs" ],
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                ]
                 input[2] = false
                 input[3] = true
                 """
@@ -75,6 +82,7 @@ nextflow_workflow {
     test("idFanCani4 - split - fasta w/ index") {
         when {
             params {
+                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -82,7 +90,10 @@ nextflow_workflow {
             workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
-                input[1] = "TTAGG"
+                input[1] = [
+                    [ id: "motifs" ],
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                ]
                 input[2] = true
                 input[3] = true
                 """
@@ -104,6 +115,7 @@ nextflow_workflow {
     test("idFanCani4 - no split - fasta w/o index") {
         when {
             params {
+                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -111,7 +123,10 @@ nextflow_workflow {
             workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
-                input[1] = "TTAGG"
+                input[1] = [
+                    [ id: "motifs" ],
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                ]
                 input[2] = false
                 input[3] = false
                 """
@@ -133,6 +148,7 @@ nextflow_workflow {
     test("idFanCani4 - split - fasta w/o index") {
         when {
             params {
+                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -140,7 +156,10 @@ nextflow_workflow {
             workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
-                input[1] = "TTAGG"
+                input[1] = [
+                    [ id: "motifs" ],
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                ]
                 input[2] = true
                 input[3] = false
                 """
@@ -162,6 +181,7 @@ nextflow_workflow {
     test("idFanCani4 - no split - fasta - stub w/o index") {
         when {
             params {
+                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -169,7 +189,10 @@ nextflow_workflow {
             workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
-                input[1] = "TTAGG"
+                input[1] = [
+                    [ id: "motifs" ],
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                ]
                 input[2] = false
                 input[3] = false
                 """

--- a/subworkflows/sanger-tol/telo_finder/tests/main.nf.test
+++ b/subworkflows/sanger-tol/telo_finder/tests/main.nf.test
@@ -59,7 +59,7 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
                     [ id: "motifs" ],
-                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = false
                 input[3] = true
@@ -92,7 +92,7 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
                     [ id: "motifs" ],
-                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = true
                 input[3] = true
@@ -125,7 +125,7 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
                     [ id: "motifs" ],
-                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = false
                 input[3] = false
@@ -158,7 +158,7 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
                     [ id: "motifs" ],
-                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = true
                 input[3] = false
@@ -191,7 +191,7 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
                     [ id: "motifs" ],
-                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motifs.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = false
                 input[3] = false

--- a/subworkflows/sanger-tol/telo_finder/tests/main.nf.test
+++ b/subworkflows/sanger-tol/telo_finder/tests/main.nf.test
@@ -49,7 +49,7 @@ nextflow_workflow {
     test("idFanCani4 - no split - fasta w/ index") {
         when {
             params {
-                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
+                bioawk_command = "-c fastx"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -58,7 +58,7 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
-                    [ id: "motifs" ],
+                    [ id:"idFanCani4" ],
                     file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = false
@@ -82,7 +82,7 @@ nextflow_workflow {
     test("idFanCani4 - split - fasta w/ index") {
         when {
             params {
-                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
+                bioawk_command = "-c fastx"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -91,7 +91,7 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
-                    [ id: "motifs" ],
+                    [ id:"idFanCani4" ],
                     file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = true
@@ -115,7 +115,7 @@ nextflow_workflow {
     test("idFanCani4 - no split - fasta w/o index") {
         when {
             params {
-                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
+                bioawk_command = "-c fastx"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -124,7 +124,7 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
-                    [ id: "motifs" ],
+                    [ id: "idFanCani4" ],
                     file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = false
@@ -148,7 +148,7 @@ nextflow_workflow {
     test("idFanCani4 - split - fasta w/o index") {
         when {
             params {
-                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
+                bioawk_command = "-c fastx"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -157,7 +157,7 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
-                    [ id: "motifs" ],
+                    [ id:"idFanCani4" ],
                     file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = true
@@ -181,7 +181,7 @@ nextflow_workflow {
     test("idFanCani4 - no split - fasta - stub w/o index") {
         when {
             params {
-                bioawk_command = "-c fastx \'{s = toupper(\$seq); copy_s = s; g = gsub(/G/, \"\", s); pct = 100*g/length(copy_s); rev = (pct > 30); out = rev ? revcomp(\$seq) : \$seq; printf \"%s\\t%d\\t%.2f\\t%s\\t%s\\n\", out, g, pct, (rev ? \"true\" : \"false\"), copy_s }\'"
+                bioawk_command = "-c fastx"
                 windows_percent = "99.9"
                 bgzip_args       = "--csi"
             }
@@ -190,7 +190,7 @@ nextflow_workflow {
                 """
                 input[0] = GUNZIP.out.gunzip
                 input[1] = [
-                    [ id: "motifs" ],
+                    [ id:"idFanCani4" ],
                     file(params.modules_testdata_base_path + 'resources/modules/telomere/generic/telomere_motif.fasta', checkIfExists: true)
                 ]
                 input[2] = false

--- a/subworkflows/sanger-tol/telo_finder/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/telo_finder/tests/main.nf.test.snap
@@ -5,15 +5,23 @@
                 "0": [
                     [
                         {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
                             "id": "idFanCani4"
                         },
                         "idFanCani4_0P_telomere.bed:md5,3ccb4acb3f33c8ff3ca3201245a42ce3"
                     ]
                 ],
-                "1": [
+                "2": [
                     
                 ],
-                "2": [
+                "3": [
                     [
                         {
                             "id": "idFanCani4"
@@ -43,6 +51,14 @@
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064"
                         ]
                     ]
+                ],
+                "telomere_summary": [
+                    [
+                        {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
                 ]
             }
         ],
@@ -50,7 +66,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-02-27T16:07:42.294323895"
+        "timestamp": "2026-03-26T12:18:37.726692775"
     },
     "idFanCani4 - no split - fasta w/o index": {
         "content": [
@@ -58,15 +74,23 @@
                 "0": [
                     [
                         {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
                             "id": "idFanCani4"
                         },
                         "idFanCani4_0P_telomere.bed:md5,3ccb4acb3f33c8ff3ca3201245a42ce3"
                     ]
                 ],
-                "1": [
+                "2": [
                     
                 ],
-                "2": [
+                "3": [
                     [
                         {
                             "id": "idFanCani4"
@@ -96,6 +120,14 @@
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064"
                         ]
                     ]
+                ],
+                "telomere_summary": [
+                    [
+                        {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
                 ]
             }
         ],
@@ -103,7 +135,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-02-27T16:01:40.077413969"
+        "timestamp": "2026-03-26T12:16:40.416549675"
     },
     "idFanCani4 - no split - fasta w/ index": {
         "content": [
@@ -111,12 +143,20 @@
                 "0": [
                     [
                         {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
                             "id": "idFanCani4"
                         },
                         "idFanCani4_0P_telomere.bed:md5,3ccb4acb3f33c8ff3ca3201245a42ce3"
                     ]
                 ],
-                "1": [
+                "2": [
                     [
                         {
                             "id": "idFanCani4"
@@ -125,7 +165,7 @@
                         "idFanCani4.bed.gz.csi:md5,c1e8ab4feb9c52665916f33ca629e055"
                     ]
                 ],
-                "2": [
+                "3": [
                     [
                         {
                             "id": "idFanCani4"
@@ -161,6 +201,14 @@
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064"
                         ]
                     ]
+                ],
+                "telomere_summary": [
+                    [
+                        {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
                 ]
             }
         ],
@@ -168,7 +216,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-02-27T15:55:30.275969768"
+        "timestamp": "2026-03-26T12:14:38.428454891"
     },
     "idFanCani4 - split - fasta w/o index": {
         "content": [
@@ -176,6 +224,14 @@
                 "0": [
                     [
                         {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
                             "id": "idFanCani4"
                         },
                         "idFanCani4_0P_telomere.bed:md5,3ccb4acb3f33c8ff3ca3201245a42ce3"
@@ -184,27 +240,27 @@
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_3P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
+                        "idFanCani4_3P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
                     ],
                     [
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_5P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
+                        "idFanCani4_5P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
                     ]
                 ],
-                "1": [
+                "2": [
                     
                 ],
-                "2": [
+                "3": [
                     [
                         {
                             "id": "idFanCani4"
                         },
                         [
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064",
-                            "idFanCani4_3P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72",
-                            "idFanCani4_5P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a"
+                            "idFanCani4_3P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a",
+                            "idFanCani4_5P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72"
                         ]
                     ]
                 ],
@@ -219,13 +275,13 @@
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_3P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
+                        "idFanCani4_3P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
                     ],
                     [
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_5P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
+                        "idFanCani4_5P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
                     ]
                 ],
                 "bed_gz_tbi": [
@@ -238,9 +294,17 @@
                         },
                         [
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064",
-                            "idFanCani4_3P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72",
-                            "idFanCani4_5P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a"
+                            "idFanCani4_3P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a",
+                            "idFanCani4_5P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72"
                         ]
+                    ]
+                ],
+                "telomere_summary": [
+                    [
+                        {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -249,7 +313,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-25T09:41:21.745905593"
+        "timestamp": "2026-03-26T12:17:39.018723616"
     },
     "idFanCani4 - split - fasta w/ index": {
         "content": [
@@ -257,6 +321,14 @@
                 "0": [
                     [
                         {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
                             "id": "idFanCani4"
                         },
                         "idFanCani4_0P_telomere.bed:md5,3ccb4acb3f33c8ff3ca3201245a42ce3"
@@ -265,16 +337,16 @@
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_3P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
+                        "idFanCani4_3P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
                     ],
                     [
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_5P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
+                        "idFanCani4_5P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
                     ]
                 ],
-                "1": [
+                "2": [
                     [
                         {
                             "id": "idFanCani4"
@@ -297,15 +369,15 @@
                         "idFanCani4.bed.gz.csi:md5,0f0441214ad7a769d6a4fb6b96446bf4"
                     ]
                 ],
-                "2": [
+                "3": [
                     [
                         {
                             "id": "idFanCani4"
                         },
                         [
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064",
-                            "idFanCani4_3P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72",
-                            "idFanCani4_5P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a"
+                            "idFanCani4_3P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a",
+                            "idFanCani4_5P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72"
                         ]
                     ]
                 ],
@@ -320,13 +392,13 @@
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_3P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
+                        "idFanCani4_3P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
                     ],
                     [
                         {
                             "id": "idFanCani4"
                         },
-                        "idFanCani4_5P_telomere.bed:md5,f01283d96943c5b99c94476f1ebfd6c5"
+                        "idFanCani4_5P_telomere.bed:md5,05f7b8e3fb9d1b507c6f77e9a6fcf5bc"
                     ]
                 ],
                 "bed_gz_tbi": [
@@ -359,9 +431,17 @@
                         },
                         [
                             "idFanCani4_0P_telomere.bedgraph:md5,f8df4805d7f8948a5bc74c674965d064",
-                            "idFanCani4_3P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72",
-                            "idFanCani4_5P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a"
+                            "idFanCani4_3P_telomere.bedgraph:md5,6cefbe69d50049775dee25c3e16f8e3a",
+                            "idFanCani4_5P_telomere.bedgraph:md5,b08b2378f33635eec98cd63744d88a72"
                         ]
+                    ]
+                ],
+                "telomere_summary": [
+                    [
+                        {
+                            "id": "motifs"
+                        },
+                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -370,6 +450,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-25T09:39:48.562122487"
+        "timestamp": "2026-03-26T12:15:42.255250176"
     }
 }

--- a/subworkflows/sanger-tol/telo_finder/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/telo_finder/tests/main.nf.test.snap
@@ -5,9 +5,9 @@
                 "0": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ],
                 "1": [
@@ -55,9 +55,9 @@
                 "telomere_summary": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -66,7 +66,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-26T12:18:37.726692775"
+        "timestamp": "2026-03-30T14:28:02.582772623"
     },
     "idFanCani4 - no split - fasta w/o index": {
         "content": [
@@ -74,9 +74,9 @@
                 "0": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ],
                 "1": [
@@ -124,9 +124,9 @@
                 "telomere_summary": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -135,7 +135,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-26T12:16:40.416549675"
+        "timestamp": "2026-03-30T14:25:52.915832969"
     },
     "idFanCani4 - no split - fasta w/ index": {
         "content": [
@@ -143,9 +143,9 @@
                 "0": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ],
                 "1": [
@@ -205,9 +205,9 @@
                 "telomere_summary": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -216,7 +216,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-26T12:14:38.428454891"
+        "timestamp": "2026-03-30T14:23:41.71430176"
     },
     "idFanCani4 - split - fasta w/o index": {
         "content": [
@@ -224,9 +224,9 @@
                 "0": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ],
                 "1": [
@@ -302,9 +302,9 @@
                 "telomere_summary": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -313,7 +313,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-26T12:17:39.018723616"
+        "timestamp": "2026-03-30T14:26:55.994519841"
     },
     "idFanCani4 - split - fasta w/ index": {
         "content": [
@@ -321,9 +321,9 @@
                 "0": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ],
                 "1": [
@@ -439,9 +439,9 @@
                 "telomere_summary": [
                     [
                         {
-                            "id": "motifs"
+                            "id": "idFanCani4"
                         },
-                        "motifs.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
+                        "idFanCani4.tsv:md5,1d21c8f15931e62f3a505dd961ae55f4"
                     ]
                 ]
             }
@@ -450,6 +450,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-03-26T12:15:42.255250176"
+        "timestamp": "2026-03-30T14:24:47.513675438"
     }
 }

--- a/subworkflows/sanger-tol/telo_finder/tests/nextflow.config
+++ b/subworkflows/sanger-tol/telo_finder/tests/nextflow.config
@@ -1,8 +1,12 @@
 nextflow.enable.moduleBinaries = true
 
 process {
+
+    withName: BIOAWK {
+        ext.args = { "${params.bioawk_command}" }
+    }
+
     withName: TELOMERE_WINDOWS {
-        tag         = { "${meta.id}_${meta.direction}P" }
         ext.args    = { "${params.windows_percent}" }
         ext.prefix  = { "${meta.id}_${meta.direction}P" }
     }


### PR DESCRIPTION
Input is now a fasta formatted file
BIOAWK is used to return a reverse compliment is G% is greater than 30%
Result is pulled from file and fed into downstream processes.
Implementation has not required any changes to files already produced.
also fixes strict syntax issue

TreeVal and CurationPretext will need to dump the params.telomotif into a fasta formatted file with a fake `>seq` header.