### PR TITLE
Use CRAM in the alignment sub-workflows

### DIFF
--- a/modules/sanger-tol/cramalign/bwamem2alignhic/main.nf
+++ b/modules/sanger-tol/cramalign/bwamem2alignhic/main.nf
@@ -13,7 +13,7 @@ process CRAMALIGN_BWAMEM2ALIGNHIC {
     tuple val(chunkn), val(range)
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.cram"), emit: cram
     tuple val("${task.process}"), val('bwamem2'), eval('bwa-mem2 version 2>| grep -o -E "[0-9]+(\\.[0-9]+)+"'), emit: versions_bwamem2, topic: versions
     tuple val("${task.process}"), val('samtools'), eval('samtools --version | head -1 | sed -e "s/samtools //"'), emit: versions_samtools, topic: versions
 
@@ -46,12 +46,12 @@ process CRAMALIGN_BWAMEM2ALIGNHIC {
         bwa-mem2 mem ${args3} -t ${task.cpus} \${INDEX} ${rg_arg} - |\\
         samtools fixmate ${args4} - - |\\
         samtools view -h ${args5} |\\
-        samtools sort ${args6} -@${task.cpus} -T ${prefix}_tmp -o ${prefix}.bam -
+        samtools sort ${args6} -@${task.cpus} -T ${prefix}_tmp --reference ${reference} -o ${prefix}.cram -
     """
 
     stub:
     def prefix  = task.ext.prefix ?: "${cram}.${chunkn}.${meta.id}"
     """
-    touch ${prefix}.bam
+    touch ${prefix}.cram
     """
 }

--- a/modules/sanger-tol/cramalign/bwamem2alignhic/meta.yml
+++ b/modules/sanger-tol/cramalign/bwamem2alignhic/meta.yml
@@ -3,7 +3,7 @@ name: "cramalign_bwamem2alignhic"
 description: |
   Aligns a subset of Hi-C reads from a CRAM file to a reference genome using bwa-mem2,
   pipes the resulting alignments through samtools fixmate and samtools sort, outputting
-  an alignment in BAM format.
+  an alignment in CRAM format.
 keywords:
   - sort
   - alignment
@@ -72,18 +72,18 @@ input:
         type: list
         description: Start and end indices defining CRAM slices to align
 output:
-  bam:
+  cram:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
-      - "*.bam":
+      - "*.cram":
           type: file
-          description: BAM file of mapped Hi-C sequences
-          pattern: "*.bam"
+          description: CRAM file of mapped Hi-C sequences
+          pattern: "*.cram"
           ontologies:
-            - edam: "http://edamontology.org/format_2572" # BAM
+            - edam: "http://edamontology.org/format_3462" # CRAM
   versions_bwamem2:
     - - ${task.process}:
           type: string

--- a/modules/sanger-tol/cramalign/bwamem2alignhic/tests/main.nf.test
+++ b/modules/sanger-tol/cramalign/bwamem2alignhic/tests/main.nf.test
@@ -64,11 +64,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -115,11 +118,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }

--- a/modules/sanger-tol/cramalign/bwamem2alignhic/tests/main.nf.test.snap
+++ b/modules/sanger-tol/cramalign/bwamem2alignhic/tests/main.nf.test.snap
@@ -33,7 +33,7 @@
                         {
                             "id": "test"
                         },
-                        "35528_2%231_subset.cram.1.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "35528_2%231_subset.cram.1.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -50,12 +50,12 @@
                         "1.22.1"
                     ]
                 ],
-                "bam": [
+                "cram": [
                     [
                         {
                             "id": "test"
                         },
-                        "35528_2%231_subset.cram.1.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "35528_2%231_subset.cram.1.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions_bwamem2": [
@@ -76,9 +76,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-15T14:27:17.465643"
+        "timestamp": "2026-03-19T13:31:01.974887493"
     },
     "meles meles - no readgroup lines": {
         "content": [

--- a/modules/sanger-tol/cramalign/minimap2align/main.nf
+++ b/modules/sanger-tol/cramalign/minimap2align/main.nf
@@ -13,7 +13,7 @@ process CRAMALIGN_MINIMAP2ALIGN {
     tuple val(chunkn), val(range)
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.cram"), emit: cram
     tuple val("${task.process}"), val('minimap2'), eval('minimap2 --version | sed "s/minimap2 //g"'), emit: versions_minimap2, topic: versions
     tuple val("${task.process}"), val('samtools'), eval('samtools --version | head -1 | sed -e "s/samtools //"'), emit: versions_samtools, topic: versions
 
@@ -40,12 +40,12 @@ process CRAMALIGN_MINIMAP2ALIGN {
         samtools fastq ${args2} - |  \\
         minimap2 -t${task.cpus} ${args3} ${index} ${rg_arg} - | \\
         ${post_filter} \\
-        samtools sort ${args5} -@${task.cpus} -T ${prefix}_sort_tmp -o ${prefix}.bam -
+        samtools sort ${args5} -@${task.cpus} -T ${prefix}_sort_tmp --reference ${reference} -o ${prefix}.cram -
     """
 
     stub:
     def prefix  = task.ext.prefix ?: "${cram}.${chunkn}.${meta.id}"
     """
-    touch ${prefix}.bam
+    touch ${prefix}.cram
     """
 }

--- a/modules/sanger-tol/cramalign/minimap2align/meta.yml
+++ b/modules/sanger-tol/cramalign/minimap2align/meta.yml
@@ -2,7 +2,7 @@
 name: "cramalign_minimap2align"
 description: |
   Aligns a subset of sequencing reads from a CRAM file to a reference genome using minimap2,
-    pipes the resulting alignments through samtools view (optional) and samtools sort, outputting an alignment in BAM format.
+    pipes the resulting alignments through samtools view (optional) and samtools sort, outputting an alignment in CRAM format.
 keywords:
   - align
   - cram
@@ -69,18 +69,18 @@ input:
         type: list
         description: Start and end indices defining CRAM slices to align
 output:
-  bam:
+  cram:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
-      - "*.bam":
+      - "*.cram":
           type: file
-          description: BAM file of mapped sequences
-          pattern: "*.bam"
+          description: CRAM file of mapped Hi-C sequences
+          pattern: "*.cram"
           ontologies:
-            - edam: "http://edamontology.org/format_2572"
+            - edam: "http://edamontology.org/format_3462" # CRAM
   versions_samtools:
     - - ${task.process}:
           type: string

--- a/modules/sanger-tol/cramalign/minimap2align/tests/main.nf.test
+++ b/modules/sanger-tol/cramalign/minimap2align/tests/main.nf.test
@@ -62,11 +62,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -111,11 +114,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -160,11 +166,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -246,11 +255,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }

--- a/modules/sanger-tol/cramalign/minimap2align/tests/main.nf.test.snap
+++ b/modules/sanger-tol/cramalign/minimap2align/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "PAE35587_pass_1f1f0707_115.subset.cram.1.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "PAE35587_pass_1f1f0707_115.subset.cram.1.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -24,12 +24,12 @@
                         "1.22.1"
                     ]
                 ],
-                "bam": [
+                "cram": [
                     [
                         {
                             "id": "test"
                         },
-                        "PAE35587_pass_1f1f0707_115.subset.cram.1.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "PAE35587_pass_1f1f0707_115.subset.cram.1.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions_minimap2": [
@@ -50,9 +50,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-15T14:40:37.641168"
+        "timestamp": "2026-03-22T14:16:55.142638265"
     },
     "Meles meles - ONT filtered reads": {
         "content": [

--- a/modules/sanger-tol/cramalign/minimap2alignhic/main.nf
+++ b/modules/sanger-tol/cramalign/minimap2alignhic/main.nf
@@ -13,7 +13,7 @@ process CRAMALIGN_MINIMAP2ALIGNHIC {
     tuple val(chunkn), val(range)
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.cram"), emit: cram
     tuple val("${task.process}"), val('minimap2'), eval('minimap2 --version | sed "s/minimap2 //g"'), emit: versions_minimap2, topic: versions
     tuple val("${task.process}"), val('gawk'), eval('gawk --version | grep -o -E "[0-9]+(\\.[0-9]+)+" | head -n1'), emit: versions_gawk, topic: versions
     tuple val("${task.process}"), val('filter_five_end.pl'), eval('echo 1.0'), emit: versions_filterfiveend, topic: versions
@@ -62,12 +62,12 @@ process CRAMALIGN_MINIMAP2ALIGNHIC {
         ' |\\
         samtools fixmate ${args4} - - |\\
         samtools view -h ${args5} |\\
-        samtools sort ${args6} -@${task.cpus} -T ${prefix}_tmp -o ${prefix}.bam -
+        samtools sort ${args6} -@${task.cpus} -T ${prefix}_tmp --reference ${reference} -o ${prefix}.cram -
     """
 
     stub:
     def prefix  = task.ext.prefix ?: "${cram}.${chunkn}.${meta.id}"
     """
-    touch ${prefix}.bam
+    touch ${prefix}.cram
     """
 }

--- a/modules/sanger-tol/cramalign/minimap2alignhic/meta.yml
+++ b/modules/sanger-tol/cramalign/minimap2alignhic/meta.yml
@@ -3,7 +3,7 @@ name: "cramalign_minimap2alignhic"
 description: |
   Aligns a subset of Hi-C reads from a CRAM file to a reference genome using minimap2,
     pipes the resulting alignments through filterfiveend.pl (included), samtools fixmate and samtools sort, outputting
-    an alignment in BAM format.
+    an alignment in CRAM format.
 keywords:
   - align
   - cram
@@ -77,18 +77,18 @@ input:
         type: list
         description: Start and end indices defining CRAM slices to align
 output:
-  bam:
+  cram:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
-      - "*.bam":
+      - "*.cram":
           type: file
-          description: BAM file of mapped Hi-C sequences
-          pattern: "*.bam"
+          description: CRAM file of mapped Hi-C sequences
+          pattern: "*.cram"
           ontologies:
-            - edam: "http://edamontology.org/format_2572" # BAM
+            - edam: "http://edamontology.org/format_3462" # CRAM
   versions_minimap2:
     - - ${task.process}:
           type: string

--- a/modules/sanger-tol/cramalign/minimap2alignhic/tests/main.nf.test
+++ b/modules/sanger-tol/cramalign/minimap2alignhic/tests/main.nf.test
@@ -64,11 +64,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -115,11 +118,14 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert process.success },
                 {
                     assert snapshot(
-                        bam(process.out.bam.get(0).get(1)).getReadsMD5(),
+                        cram(process.out.cram.get(0).get(1), fasta).getReadsMD5(),
                         process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }

--- a/modules/sanger-tol/cramalign/minimap2alignhic/tests/main.nf.test.snap
+++ b/modules/sanger-tol/cramalign/minimap2alignhic/tests/main.nf.test.snap
@@ -47,7 +47,7 @@
                         {
                             "id": "test"
                         },
-                        "35528_2%231_subset.cram.1.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "35528_2%231_subset.cram.1.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -78,12 +78,12 @@
                         "1.22.1"
                     ]
                 ],
-                "bam": [
+                "cram": [
                     [
                         {
                             "id": "test"
                         },
-                        "35528_2%231_subset.cram.1.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "35528_2%231_subset.cram.1.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions_filterfiveend": [
@@ -118,9 +118,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-15T14:47:03.804302"
+        "timestamp": "2026-03-22T14:22:25.149371366"
     },
     "meles meles - no readgroup lines": {
         "content": [

--- a/modules/sanger-tol/fastxalign/minimap2align/main.nf
+++ b/modules/sanger-tol/fastxalign/minimap2align/main.nf
@@ -11,10 +11,10 @@ process FASTXALIGN_MINIMAP2ALIGN {
     tuple val(meta),  path(fastx), path(fxi)
     tuple val(meta2), path(index), path(reference)
     tuple val(chunkn), val(range)
-    val bam_format
+    val cram_format
 
     output:
-    tuple val(meta), path("*.bam")   , emit: bam, optional: true
+    tuple val(meta), path("*.cram")  , emit: cram, optional: true
     tuple val(meta), path("*.paf.gz"), emit: paf, optional: true
     tuple val("${task.process}"), val('slice_fasta.py'), eval('slice_fasta.py --version'), emit: versions_slice_fasta, topic: versions
     tuple val("${task.process}"), val('samtools'), eval('samtools version | sed "1!d;s/.* //"'), emit: versions_samtools, topic: versions
@@ -34,18 +34,19 @@ process FASTXALIGN_MINIMAP2ALIGN {
     def args3       = task.ext.args3  ?: ''
     def prefix      = task.ext.prefix ?: "${fastx}.${chunkn}.${meta.id}"
     def post_filter = args2 ? "samtools view -h ${args2} - |" : ''
-    def sort_bam    = "samtools sort -@ ${task.cpus > 1 ? task.cpus - 1 : 1} -o ${prefix}.bam -T ${prefix}_sort_tmp ${args3} -"
-    def bam_output  = bam_format      ? "-a | ${post_filter} ${sort_bam}" : "| bgzip -@ ${task.cpus} > ${prefix}.paf.gz"
+    def fasta       = reference       ?: index
+    def sort_cram   = "samtools sort -@ ${task.cpus > 1 ? task.cpus - 1 : 1} -o ${prefix}.cram --reference ${fasta} -T ${prefix}_sort_tmp ${args3} -"
+    def cram_output = cram_format     ? "-a | ${post_filter} ${sort_cram}" : "| bgzip -@ ${task.cpus} > ${prefix}.paf.gz"
     """
     slice_fasta.py slice ${fastx} ${range[0]} ${range[1]} | \\
         minimap2 -t${task.cpus} ${args} ${index} - \\
-        ${bam_output}
+        ${cram_output}
     """
 
     stub:
     def prefix  = task.ext.prefix ?: "${fastx}.${chunkn}.${meta.id}"
     """
-    touch ${prefix}.bam
+    touch ${prefix}.cram
     echo "" | gzip > ${prefix}.paf.gz
     """
 }

--- a/modules/sanger-tol/fastxalign/minimap2align/meta.yml
+++ b/modules/sanger-tol/fastxalign/minimap2align/meta.yml
@@ -3,7 +3,7 @@ name: "fastxalign_minimap2align"
 description: |
   Aligns a subset of sequencing reads from a FASTx file to a reference genome using minimap2. Can either
   output the alignment in PAF format, or alternatively will pipe the resulting alignments through
-  samtools view and samtools sort, outputting an alignment in BAM format.
+  samtools view and samtools sort, outputting an alignment in CRAM format.
 keywords:
   - align
   - fasta
@@ -78,20 +78,20 @@ input:
         type: list
         description: Start and end indices defining FASTA slices to align,
           0-indexed
-  - bam_format:
+  - cram_format:
       type: boolean
-      description: Output PAF format or BAM format alignments
+      description: Output PAF format or CRAM format alignments
 output:
-  bam:
+  cram:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
-      - "*.bam":
+      - "*.cram":
           type: file
-          description: BAM file of mapped sequences
-          pattern: "*.bam"
+          description: CRAM file of mapped sequences
+          pattern: "*.cram"
           ontologies:
             - edam: "http://edamontology.org/format_2572"
   paf:

--- a/modules/sanger-tol/fastxalign/minimap2align/tests/main.nf.test
+++ b/modules/sanger-tol/fastxalign/minimap2align/tests/main.nf.test
@@ -26,7 +26,7 @@ nextflow_process {
         }
     }
 
-    test("Undibacterium_unclassified - fasta - bam out - no filter") {
+    test("Undibacterium_unclassified - fasta - cram out - no filter") {
 
         when {
 
@@ -54,10 +54,13 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap1.p_ctg.fa'
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    bam(process.out.bam.get(0).get(1)).getStatistics(),
+                    cram(process.out.cram.get(0).get(1), fasta).getStatistics(),
                     process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -65,7 +68,7 @@ nextflow_process {
         }
     }
 
-    test("Undibacterium_unclassified - fasta - bam out - filter") {
+    test("Undibacterium_unclassified - fasta - cram out - filter") {
 
         when {
 
@@ -93,10 +96,13 @@ nextflow_process {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap1.p_ctg.fa'
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    bam(process.out.bam.get(0).get(1)).getStatistics(),
+                    cram(process.out.cram.get(0).get(1), fasta).getStatistics(),
                     process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
@@ -140,7 +146,7 @@ nextflow_process {
 
     }
 
-    test("sarscov2 - bam - stub") {
+    test("sarscov2 - cram - stub") {
 
         options "-stub"
 

--- a/modules/sanger-tol/fastxalign/minimap2align/tests/main.nf.test.snap
+++ b/modules/sanger-tol/fastxalign/minimap2align/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Undibacterium_unclassified - fasta - bam out - filter": {
+    "Undibacterium_unclassified - fasta - cram out - filter": {
         "content": [
             {
                 "maxReadLength": 26308,
@@ -40,9 +40,9 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2026-02-09T16:40:48.934235"
+        "timestamp": "2026-04-13T09:21:30.464725869"
     },
-    "sarscov2 - bam - stub": {
+    "sarscov2 - cram - stub": {
         "content": [
             {
                 "0": [
@@ -50,7 +50,7 @@
                         {
                             "id": "test"
                         },
-                        "HiFi.reads.fasta.0.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "HiFi.reads.fasta.0.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -82,12 +82,12 @@
                         "2.30-r1287"
                     ]
                 ],
-                "bam": [
+                "cram": [
                     [
                         {
                             "id": "test"
                         },
-                        "HiFi.reads.fasta.0.test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "HiFi.reads.fasta.0.test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "paf": [
@@ -125,9 +125,9 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2026-02-09T16:41:04.114202"
+        "timestamp": "2026-04-13T09:14:28.767123325"
     },
-    "Undibacterium_unclassified - fasta - bam out - no filter": {
+    "Undibacterium_unclassified - fasta - cram out - no filter": {
         "content": [
             {
                 "maxReadLength": 26308,
@@ -168,7 +168,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2026-02-09T16:40:40.802654"
+        "timestamp": "2026-04-13T09:21:22.879309064"
     },
     "Undibacterium_unclassified - fasta - paf out": {
         "content": [
@@ -205,7 +205,7 @@
                         "2.30-r1287"
                     ]
                 ],
-                "bam": [
+                "cram": [
                     
                 ],
                 "paf": [
@@ -243,6 +243,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2026-02-09T16:40:57.327797"
+        "timestamp": "2026-04-13T09:14:22.596178402"
     }
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -13,7 +13,7 @@ config {
 
     // load the necessary plugins
     plugins {
-        load "nft-bam@0.6.0"
+        load "nft-bam@0.6.1"
         load "nft-utils@0.0.8"
         load "nft-vcf@1.0.7"
     }

--- a/subworkflows/sanger-tol/bam_samtools_merge_markdup/meta.yml
+++ b/subworkflows/sanger-tol/bam_samtools_merge_markdup/meta.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/nf-core-modules/main/subworkflows/yaml-schema.json
 name: "bam_samtools_merge_markdup"
 description: |
-  Merge sorted fixmated BAM files with reference to an assembly, then optionally mark duplicates
+  Merge sorted fixmated BAM/CRAM/SAM files with reference to an assembly, then optionally mark duplicates
 keywords:
   - bam
   - merge
@@ -33,9 +33,9 @@ output:
   - bam:
       type: file
       description: |
-        Channel containing merged and possibly duplicate-marked BAM files
+        Channel containing merged and possibly duplicate-marked BAM/CRAM/SAM files
         Structure: [ val(meta), path(bam) ]
-      pattern: "*.bam"
+      pattern: "*.{bam,cram,sam}"
   - bam_index:
       type: file
       description: |
@@ -47,7 +47,7 @@ output:
       description: |
         Channel containing markdup metrics, if duplicates marked
         Structure: [ val(meta), path(index) ]
-      pattern: "*.{bai,csi,crai}"
+      pattern: "*.metrics"
 authors:
   - "@prototaxites"
 maintainers:

--- a/subworkflows/sanger-tol/cram_map_illumina_hic/main.nf
+++ b/subworkflows/sanger-tol/cram_map_illumina_hic/main.nf
@@ -122,7 +122,7 @@ workflow CRAM_MAP_ILLUMINA_HIC {
             ch_mapping_inputs.slices
         )
 
-        ch_mapped_bams = CRAMALIGN_BWAMEM2ALIGNHIC.out.bam
+        ch_mapped_crams = CRAMALIGN_BWAMEM2ALIGNHIC.out.cram
     } else if(val_aligner == "minimap2") {
         //
         // MODULE: generate minimap2 mmi file
@@ -144,28 +144,28 @@ workflow CRAM_MAP_ILLUMINA_HIC {
             ch_mapping_inputs.slices
         )
 
-        ch_mapped_bams = CRAMALIGN_MINIMAP2ALIGNHIC.out.bam
+        ch_mapped_crams = CRAMALIGN_MINIMAP2ALIGNHIC.out.cram
     } else {
         error("Unsupported aligner: ${val_aligner}")
     }
 
     //
-    // Logic: Prepare input for merging bams.
+    // Logic: Prepare input for merging crams.
     //        We use the ch_n_cram_chunks to set a groupKey so that
-    //        we emit groups downstream ASAP once all bams have been made
+    //        we emit groups downstream ASAP once all crams have been made
     //
-    ch_merge_input = ch_mapped_bams
+    ch_merge_input = ch_mapped_crams
         .combine(ch_n_cram_chunks, by: 0)
-        .map { meta, bam, n_chunks ->
+        .map { meta, cram, n_chunks ->
             def key = groupKey(meta, n_chunks)
-            [key, bam]
+            [key, cram]
         }
         .groupTuple(by: 0)
-        .map { key, bam -> [key.target, bam.sort { b -> b.getName() }] }
+        .map { key, cram -> [key.target, cram.sort { b -> b.getName() }] }
 
 
     //
-    // Subworkflow: merge BAM files and mark duplicates
+    // Subworkflow: merge CRAM files and mark duplicates
     //
     BAM_SAMTOOLS_MERGE_MARKDUP(
         ch_merge_input,
@@ -174,7 +174,7 @@ workflow CRAM_MAP_ILLUMINA_HIC {
     )
 
     emit:
-    bam               = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam
-    bam_index         = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam_index
-    bam_markdup_stats = BAM_SAMTOOLS_MERGE_MARKDUP.out.metrics
+    cram               = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam
+    cram_index         = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam_index
+    cram_markdup_stats = BAM_SAMTOOLS_MERGE_MARKDUP.out.metrics
 }

--- a/subworkflows/sanger-tol/cram_map_illumina_hic/meta.yml
+++ b/subworkflows/sanger-tol/cram_map_illumina_hic/meta.yml
@@ -6,6 +6,7 @@ keywords:
   - hic
   - align
   - bam
+  - cram
 components:
   - cramalign/gencramchunks
   - cramalign/bwamem2alignhic
@@ -41,20 +42,26 @@ input:
       description: Size of chunk to split CRAM files into
   - val_mark_duplicates:
       type: boolean
-      description: Whether to mark duplicates on the merged BAM or not
+      description: Whether to mark duplicates on the merged CRAM or not
 output:
-  - bam:
+  - cram:
       type: file
       description: |
-        Channel containing the BAM files describing Hi-C alignments to the input assemblies
-        Structure: [ val(meta), path(bam) ]
-      pattern: "*.bam"
-  - bam_index:
+        Channel containing the CRAM files describing Hi-C alignments to the input assemblies
+        Structure: [ val(meta), path(cram) ]
+      pattern: "*.cram"
+  - cram_index:
       type: file
       description: |
-        Channel containing the indexes for the output BAM
-        Structure: [ val(meta), path(bam) ]
+        Channel containing the indexes for the output CRAM
+        Structure: [ val(meta), path(cram) ]
       pattern: "*.{bai,csi,crai}"
+  - cram_markdup_stats:
+      type: file
+      description: |
+        Channel containing the duplicate-marking metrics, if selected
+        Structure: [ val(meta), path(metrics) ]
+      pattern: "*.metrics"
 authors:
   - "@prototaxites"
 maintainers:

--- a/subworkflows/sanger-tol/cram_map_illumina_hic/tests/main.nf.test
+++ b/subworkflows/sanger-tol/cram_map_illumina_hic/tests/main.nf.test
@@ -74,14 +74,17 @@ nextflow_workflow {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 1 },
+                { assert workflow.out.cram.size() == 1 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam_markdup_stats,
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram_markdup_stats,
                     ).match()
                 }
             )
@@ -138,14 +141,18 @@ nextflow_workflow {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta1 = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
+            def fasta2 = fasta_base + 'Zymo_D6311_Metagenome/assembly/xyTesTing1_metamdbg.contigs.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 2 },
+                { assert workflow.out.cram.size() == 2 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam_markdup_stats,
+                        workflow.out.cram.collect { cram(it.get(1), file(it.get(1)).getName().contains("GCA_922984935.2") ? fasta1 : fasta2).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram_markdup_stats,
                     ).match()
                 }
             )
@@ -207,19 +214,22 @@ nextflow_workflow {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 2 },
+                { assert workflow.out.cram.size() == 2 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam.collect {
-                            def rg = bam(it.get(1)).getHeader().toString().split(", ").findAll { it.startsWith('@RG') }
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram.collect {
+                            def rg = cram(it.get(1), fasta).getHeader().toString().split(", ").findAll { it.startsWith('@RG') }
                             def sm = rg ? rg[0].split('\t').findAll { it.contains('SM') }[0] : 'no RG'
                             return "${it[0].id}: ${sm}"
                         }.sort(),
-                        workflow.out.bam_markdup_stats,
+                        workflow.out.cram_markdup_stats,
                     ).match()
                 }
             )
@@ -264,14 +274,17 @@ nextflow_workflow {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 1 },
+                { assert workflow.out.cram.size() == 1 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam_markdup_stats,
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram_markdup_stats,
                     ).match()
                 }
             )
@@ -318,14 +331,17 @@ nextflow_workflow {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Biemna_sp_UH_2024/assembly/release/GCA_965654295.1/insdc/GCA_965654295.1.fa'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 1 },
+                { assert workflow.out.cram.size() == 1 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam_markdup_stats,
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram_markdup_stats,
                     ).match()
                 }
             )
@@ -371,14 +387,17 @@ nextflow_workflow {
         }
 
         then {
+            // Fasta file for cram verification with nft-bam. Can't use params
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Biemna_sp_UH_2024/assembly/release/GCA_965654295.1/insdc/GCA_965654295.1.fa'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 1 },
+                { assert workflow.out.cram.size() == 1 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam_markdup_stats,
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram_markdup_stats,
                     ).match()
                 }
             )

--- a/subworkflows/sanger-tol/cram_map_illumina_hic/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/cram_map_illumina_hic/tests/main.nf.test.snap
@@ -26,11 +26,11 @@
                 ]
             ]
         ],
-        "timestamp": "2026-02-10T10:43:38.748216",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        }
+        },
+        "timestamp": "2026-02-10T10:43:38.748216"
     },
     "meles meles - bwamem2": {
         "content": [
@@ -59,11 +59,11 @@
                 ]
             ]
         ],
-        "timestamp": "2026-02-10T10:39:34.946622",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        }
+        },
+        "timestamp": "2026-02-10T10:39:34.946622"
     },
     "meles meles - minimap2": {
         "content": [
@@ -92,11 +92,11 @@
                 ]
             ]
         ],
-        "timestamp": "2026-02-10T10:42:47.872589",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        }
+        },
+        "timestamp": "2026-02-10T10:42:47.872589"
     },
     "meles meles - zymo - bwamem2 - multiple samples - double files": {
         "content": [
@@ -143,11 +143,11 @@
                 ]
             ]
         ],
-        "timestamp": "2026-02-10T10:41:09.214803",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        }
+        },
+        "timestamp": "2026-02-10T10:41:09.214803"
     },
     "meles meles - multiple read groups - bwamem2": {
         "content": [
@@ -176,11 +176,11 @@
                 ]
             ]
         ],
-        "timestamp": "2026-02-10T10:45:13.292929",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        }
+        },
+        "timestamp": "2026-02-10T10:45:13.292929"
     },
     "meles meles - bwamem2 - multiple samples - meta mismatch": {
         "content": [
@@ -231,10 +231,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-02-10T10:42:06.647189",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        }
+        },
+        "timestamp": "2026-02-10T10:42:06.647189"
     }
 }

--- a/subworkflows/sanger-tol/cram_map_long_reads/main.nf
+++ b/subworkflows/sanger-tol/cram_map_long_reads/main.nf
@@ -115,18 +115,18 @@ workflow CRAM_MAP_LONG_READS {
     )
 
     //
-    // Logic: Prepare input for merging bams.
+    // Logic: Prepare input for merging crams.
     //        We use the ch_n_cram_chunks to set a groupKey so that
-    //        we emit groups downstream ASAP once all bams have been made
+    //        we emit groups downstream ASAP once all crams have been made
     //
-    ch_merge_input = CRAMALIGN_MINIMAP2ALIGN.out.bam
+    ch_merge_input = CRAMALIGN_MINIMAP2ALIGN.out.cram
         .combine(ch_n_cram_chunks, by: 0)
-        .map { meta, bam, n_chunks ->
+        .map { meta, cram, n_chunks ->
             def key = groupKey(meta, n_chunks)
-            [key, bam]
+            [key, cram]
         }
         .groupTuple(by: 0)
-        .map { key, bam -> [key.target, bam.sort { b -> b.getName() }] } // Get meta back out of groupKey
+        .map { key, cram -> [key.target, cram.sort { b -> b.getName() }] } // Get meta back out of groupKey
 
     //
     // Subworkflow: merge BAM files and mark duplicates
@@ -138,6 +138,6 @@ workflow CRAM_MAP_LONG_READS {
     )
 
     emit:
-    bam               = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam
-    bam_index         = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam_index
+    cram              = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam
+    cram_index        = BAM_SAMTOOLS_MERGE_MARKDUP.out.bam_index
 }

--- a/subworkflows/sanger-tol/cram_map_long_reads/meta.yml
+++ b/subworkflows/sanger-tol/cram_map_long_reads/meta.yml
@@ -6,7 +6,7 @@ keywords:
   - pacbio
   - ont
   - align
-  - bam
+  - cram
 components:
   - cramalign/gencramchunks
   - cramalign/minimap2align
@@ -36,12 +36,18 @@ input:
       description: Size of chunk to split CRAM files into
 
 output:
-  - bam:
+  - cram:
       type: file
       description: |
-        Channel containing the BAM files describing long-read alignments to the input assemblies
-        Structure: [ val(meta), path(bam) ]
-      pattern: "*.bam"
+        Channel containing the CRAM files describing long-read alignments to the input assemblies
+        Structure: [ val(meta), path(cram) ]
+      pattern: "*.cram"
+  - cram_index:
+      type: file
+      description: |
+        Channel containing the index file(s) for the CRAM files
+        Structure: [ val(meta), path(index) ]
+      pattern: "*.{csi,crai}"
 authors:
   - "@prototaxites"
   - "@sainsachiko"

--- a/subworkflows/sanger-tol/cram_map_long_reads/tests/main.nf.test
+++ b/subworkflows/sanger-tol/cram_map_long_reads/tests/main.nf.test
@@ -65,13 +65,15 @@ nextflow_workflow {
         }
 
         then {
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 1 },
+                { assert workflow.out.cram.size() == 1 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
                     ).match()
                 }
             )
@@ -122,15 +124,17 @@ nextflow_workflow {
         }
 
         then {
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 2 },
+                { assert workflow.out.cram.size() == 2 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam.collect {
-                            def rg = bam(it.get(1)).getHeader().toString().split(", ").findAll { it.startsWith('@RG') }
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram.collect {
+                            def rg = cram(it.get(1), fasta).getHeader().toString().split(", ").findAll { it.startsWith('@RG') }
                             def sm = rg ? rg[0].split('\t').findAll { it.contains('SM') }[0] : 'no RG'
                             return "${it[0].id}: ${sm}"
                         }.sort(),
@@ -184,13 +188,15 @@ nextflow_workflow {
         }
 
         then {
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 1 },
+                { assert workflow.out.cram.size() == 1 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
                     ).match()
                 }
             )
@@ -244,15 +250,17 @@ nextflow_workflow {
         }
 
         then {
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.fasta'
             assertAll(
                 { assert workflow.success },
-                { assert workflow.out.bam.size() == 2 },
+                { assert workflow.out.cram.size() == 2 },
                 {
                     assert snapshot(
-                        workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                        workflow.out.bam_index.collect { file(it.get(1)).getName() },
-                        workflow.out.bam.collect {
-                            def rg = bam(it.get(1)).getHeader().toString().split(", ").findAll { it.startsWith('@RG') }
+                        workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() }.sort(),
+                        workflow.out.cram_index.collect { file(it.get(1)).getName() },
+                        workflow.out.cram.collect {
+                            def rg = cram(it.get(1), fasta).getHeader().toString().split(", ").findAll { it.startsWith('@RG') }
                             def sm = rg ? rg[0].split('\t').findAll { it.contains('SM') }[0] : 'no RG'
                             return "${it[0].id}: ${sm}"
                         }.sort(),

--- a/subworkflows/sanger-tol/cram_map_long_reads/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/cram_map_long_reads/tests/main.nf.test.snap
@@ -26,19 +26,19 @@
                 }
             ],
             [
-                "test1.bam.csi",
-                "test.bam.csi"
+                "test1.cram.crai",
+                "test.cram.crai"
             ],
             [
                 "test1: no RG",
                 "test: SM:mMelMel3"
             ]
         ],
-        "timestamp": "2026-03-06T10:54:38.332646",
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        }
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-18T09:16:11.01531781"
     },
     "meles meles - mismatch meta test": {
         "content": [
@@ -56,14 +56,14 @@
                 }
             ],
             [
-                "test.bam.csi"
+                "test.cram.crai"
             ]
         ],
-        "timestamp": "2026-03-06T10:55:33.006003",
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        }
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-18T09:17:26.406108354"
     },
     "meles meles - PacBio Hifi test - double files": {
         "content": [
@@ -92,19 +92,19 @@
                 }
             ],
             [
-                "test1.bam.csi",
-                "test.bam.csi"
+                "test1.cram.crai",
+                "test.cram.crai"
             ],
             [
                 "test1: SM:test1",
                 "test: SM:mMelMel3"
             ]
         ],
-        "timestamp": "2026-03-06T10:57:56.387344",
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        }
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-18T09:20:29.290734588"
     },
     "meles meles - single test": {
         "content": [
@@ -122,13 +122,13 @@
                 }
             ],
             [
-                "test.bam.csi"
+                "test.cram.crai"
             ]
         ],
-        "timestamp": "2026-03-06T10:53:26.260999",
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        }
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-18T09:14:31.827689301"
     }
 }

--- a/subworkflows/sanger-tol/fastx_map_long_reads/main.nf
+++ b/subworkflows/sanger-tol/fastx_map_long_reads/main.nf
@@ -10,7 +10,7 @@ workflow FASTX_MAP_LONG_READS {
     ch_assemblies             // Channel [meta, assembly]
     ch_fasta                  // Channel [meta, fasta] OR [meta, [fasta1, fasta2, ..., fasta_n]]
     val_reads_per_fasta_chunk // integer: Number of reads per FASTA chunk for mapping
-    val_output_bam            // boolean: if true output alignments in BAM format
+    val_output_cram           // boolean: if true output alignments in BAM format
 
     main:
     //
@@ -81,7 +81,7 @@ workflow FASTX_MAP_LONG_READS {
         ch_fasta_with_slices.fastx,
         ch_fasta_with_slices.reference,
         ch_fasta_with_slices.slices,
-        val_output_bam
+        val_output_cram
     )
 
     //
@@ -101,35 +101,35 @@ workflow FASTX_MAP_LONG_READS {
     // Logic: Group all BAM files together for merging, using a groupKey to
     //        output when reaching the expected count of PAF files
     //
-    ch_merge_input = FASTXALIGN_MINIMAP2ALIGN.out.bam
+    ch_merge_input = FASTXALIGN_MINIMAP2ALIGN.out.cram
         .combine(ch_n_fasta_chunks, by: 0)
-        .map { meta, bam, n_chunks ->
+        .map { meta, cram, n_chunks ->
             def key = groupKey(meta, n_chunks)
-            [key, bam]
+            [key, cram]
         }
-        .groupTuple(by: 0, sort: { bam -> bam.getName() } )
-        .map { key, bam -> [key.target, bam] } // Get meta back out of groupKey
+        .groupTuple(by: 0, sort: { cram -> cram.getName() } )
+        .map { key, cram -> [key.target, cram] } // Get meta back out of groupKey
 
     //
     // Logic: Wrap this in the conditional so we don't unnecessarily run
-    //        samtools faidx if no bam output
+    //        samtools faidx if no cram output
     //
-    ch_output_bam       = channel.empty()
-    ch_output_bam_index = channel.empty()
+    ch_output_cram       = channel.empty()
+    ch_output_cram_index = channel.empty()
 
-    if(val_output_bam) {
+    if(val_output_cram) {
         BAM_SAMTOOLS_MERGE_MARKDUP(
             ch_merge_input,
             ch_assemblies,
             false
         )
 
-        ch_output_bam       = ch_output_bam.mix(BAM_SAMTOOLS_MERGE_MARKDUP.out.bam)
-        ch_output_bam_index = ch_output_bam.mix(BAM_SAMTOOLS_MERGE_MARKDUP.out.bam_index)
+        ch_output_cram       = ch_output_cram.mix(BAM_SAMTOOLS_MERGE_MARKDUP.out.bam)
+        ch_output_cram_index = ch_output_cram.mix(BAM_SAMTOOLS_MERGE_MARKDUP.out.bam_index)
     }
 
     emit:
-    bam       = ch_output_bam
-    bam_index = ch_output_bam_index
-    paf       = ch_grouped_paf
+    cram       = ch_output_cram
+    cram_index = ch_output_cram_index
+    paf        = ch_grouped_paf
 }

--- a/subworkflows/sanger-tol/fastx_map_long_reads/tests/main.nf.test
+++ b/subworkflows/sanger-tol/fastx_map_long_reads/tests/main.nf.test
@@ -61,7 +61,7 @@ nextflow_workflow {
         }
     }
 
-    test("Undibacterium unclassified - fasta - bam") {
+    test("Undibacterium unclassified - fasta - cram") {
 
         when {
 
@@ -81,11 +81,13 @@ nextflow_workflow {
             }
         }
         then {
+            def fasta_base = 'https://tolit.cog.sanger.ac.uk/test-data/'
+            def fasta = fasta_base + 'Undibacterium_unclassified/assembly/draft/baUndUnlc1.hic.hap1.p_ctg.unscaffolded.fa'
             assert workflow.success
             assertAll(
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it.get(1)).getStatistics() },
-                    workflow.out.bam_index.collect { file(it.get(1)).getName() },
+                    workflow.out.cram.collect { cram(it.get(1), fasta).getStatistics() },
+                    workflow.out.cram_index.collect { file(it.get(1)).getName() },
                 ).match() }
             )
         }
@@ -94,7 +96,7 @@ nextflow_workflow {
         }
     }
 
-    test("Undibacterium unclassified - Meles meles - fasta - bam - double files") {
+    test("Undibacterium unclassified - Meles meles - fasta - cram - double files") {
 
         when {
 
@@ -130,11 +132,12 @@ nextflow_workflow {
         }
 
         then {
+            // TODO: insert the Fasta files (there are two !)
             assert workflow.success
             assertAll(
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it.get(1)).getStatistics() }.sort(),
-                    workflow.out.bam_index.collect { file(it.get(1)).getName() }.sort(),
+                    workflow.out.cram.collect { bam(it.get(1)).getStatistics() }.sort(),
+                    workflow.out.cram_index.collect { file(it.get(1)).getName() }.sort(),
                 ).match() }
             )
         }

--- a/subworkflows/sanger-tol/fastx_map_long_reads/tests/main.nf.test.snap
+++ b/subworkflows/sanger-tol/fastx_map_long_reads/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Undibacterium unclassified - Meles meles - fasta - bam - double files": {
+    "Undibacterium unclassified - Meles meles - fasta - cram - double files": {
         "content": [
             [
                 {
@@ -36,31 +36,6 @@
         },
         "timestamp": "2026-02-10T10:38:20.394754"
     },
-    "Undibacterium unclassified - fasta - bam": {
-        "content": [
-            [
-                {
-                    "maxReadLength": 26402,
-                    "minReadLength": 0,
-                    "meanReadLength": 7644,
-                    "maxQuality": 60,
-                    "minQuality": 0,
-                    "meanQuality": 54,
-                    "readCount": 1038,
-                    "duplicateReadCount": 0,
-                    "sorted": false
-                }
-            ],
-            [
-                "test.bam"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-10T10:36:33.71967"
-    },
     "Undibacterium unclassified - fasta - paf": {
         "content": [
             [
@@ -83,5 +58,30 @@
             "nextflow": "25.10.3"
         },
         "timestamp": "2026-02-10T10:36:03.255886"
+    },
+    "Undibacterium unclassified - fasta - cram": {
+        "content": [
+            [
+                {
+                    "maxReadLength": 26402,
+                    "minReadLength": 0,
+                    "meanReadLength": 7644,
+                    "maxQuality": 60,
+                    "minQuality": 0,
+                    "meanQuality": 54,
+                    "readCount": 1038,
+                    "duplicateReadCount": 0,
+                    "sorted": false
+                }
+            ],
+            [
+                "test.cram"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-18T11:14:07.679399445"
     }
 }


### PR DESCRIPTION
Not sure how useful it is, but here is the start of a PR for using CRAM instead of BAM in the alignment modules and sub-workflows.
I expect that would significantly decrease the storage footprint of the pipelines, but I should actually benchmark that. 

The change is essentially "bam" → "cram" and adding the reference parameter in the samtools command.
Note: nft-bam doesn't support compressed fasta (issue raised) so those tests are with the uncompressed fasta for now.

I'm not going to address failing CI now:

- linter is now complaining we use `meta.sample` and `ext.args1` (new check from nf-core)
- One of the `fastx_map_long_reads` tests uses two references. I haven't updated the tests to find which reference to use

Importantly, we'll have to check who is using the alignment components in pipelines and if they can accommodate CRAM.

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] If you've added or modified a sub-workflow, ensure all sub-analyses are emitted as individual channels. Outputs may also be collected together by analysis type or input sample, for instance to support downstream analysis or publishing.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
