### PR TITLE
Strict syntax miss

### DIFF
--- a/subworkflows/sanger-tol/fasta_purge_retained_haplotype/main.nf
+++ b/subworkflows/sanger-tol/fasta_purge_retained_haplotype/main.nf
@@ -26,7 +26,7 @@ workflow FASTA_PURGE_RETAINED_HAPLOTYPE {
     // Logic: validate that input assemblies are unzipped
     //
     ch_assemblies
-        .subscribe { meta, hap1, hap2 ->
+        .subscribe { _meta, hap1, hap2 ->
             if (hap1.getExtension() == "gz" || (hap2 && hap2.getExtension() == "gz")) {
                 error("Error: Input assemblies to FASTA_PURGE_RETAINED_HAPLOTYPE must be unzipped!")
             }


### PR DESCRIPTION

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] If you've added or modified a sub-workflow, ensure all sub-analyses are emitted as individual channels. Outputs may also be collected together by analysis type or input sample, for instance to support downstream analysis or publishing.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
