### PR TITLE
Avoid DBUS warnings on Linux

### DIFF
--- a/scripts/logo/render_logo.py
+++ b/scripts/logo/render_logo.py
@@ -1,6 +1,8 @@
 #!/software/treeoflife/conda/users/envs/tol/nf-core_4.0/bin/python3
 
 import argparse
+import os
+import platform
 import re
 import shutil
 import subprocess
@@ -365,15 +367,21 @@ def format_length(value: float, unit: str) -> str:
 
 def export_svg_to_png(inkscape_cmd: str, input_path: Path, output_path: Path) -> None:
     """Run Inkscape to export an SVG file to a PNG file."""
-    subprocess.check_call(
-        [
-            inkscape_cmd,
-            str(input_path),
-            "--export-type=png",
-            "--export-filename",
-            str(output_path),
-        ]
-    )
+    cmd = [
+        inkscape_cmd,
+        str(input_path),
+        "--export-type=png",
+        "--export-filename",
+        str(output_path),
+    ]
+    # Only use dbus-run-session on Linux when no session bus exists
+    if (
+        platform.system() == "Linux"
+        and not os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+        and shutil.which("dbus-run-session")
+    ):
+        cmd = ["dbus-run-session", "--", *cmd]
+    subprocess.check_call(cmd)
 
 
 def build_logo(


### PR DESCRIPTION
On the farm, inkscape prints these error messages
```
Failed to get connection
** (inkscape:971174): CRITICAL **: 15:46:34.352: dbus_g_proxy_new_for_name: assertion 'connection != NULL' failed

** (inkscape:971174): CRITICAL **: 15:46:34.352: dbus_g_proxy_call: assertion 'DBUS_IS_G_PROXY (proxy)' failed

** (inkscape:971174): CRITICAL **: 15:46:34.352: dbus_g_connection_register_g_object: assertion 'connection != NULL' failed
```
though the command still completes.

I've tried doing `ssh -X`, adding `--without-gui`, and other things, but it turns out the problem is the lack of a DBus session. The workaround is simply to add one with `dbus-run-session`.

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] If you've added or modified a sub-workflow, ensure all sub-analyses are emitted as individual channels. Outputs may also be collected together by analysis type or input sample, for instance to support downstream analysis or publishing.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
