### PR TITLE
Update meta.yml

### DIFF
--- a/subworkflows/sanger-tol/telo_finder/meta.yml
+++ b/subworkflows/sanger-tol/telo_finder/meta.yml
@@ -11,8 +11,7 @@ keywords:
   - fasta
   - tabix
 components:
-  - findtelomere
-  - sanger-tol/telomere/findtelomere
+  - telomere/findtelomere
   - tabix/bgziptabix:
       git_remote: https://github.com/nf-core/modules.git
 input:


### PR DESCRIPTION
Correct the import statement

```

(nf-core_3.5) dp24@tol22-oversubscribed07:[dp24/curationpretext] (telomere_update):$: nf-core subworkflow --git-remote https://github.com/sanger-tol/nf-core-modules install telo_finder


                                          ,--./,-.
          ___     __   __   __   ___     /,-._.--~\
    |\ | |__  __ /  ` /  \ |__) |__         }  {
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'

    nf-core/tools version 3.5.2 - https://nf-co.re
    There is a new version of nf-core/tools available! (4.0.2)


INFO     Installing 'telo_finder'
ERROR    Module 'findtelomere' not found in available modules
╭─ info ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                 │
│ Use the command nf-core modules list to view available modules.                                                                                                 │
│                                                                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
ERROR
```

It can't validate just findtelomere

I don't think it'll be able to do sanger-tol/telomere/findtelomere either, style in other subworkflows is just `telomere/findtelomere`
