### PR TITLE
Use nft-csv to make the CSV content visible in the snapshot

### DIFF
--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -52,9 +52,9 @@ def parse_args(args=None):
     parser.add_argument(
         "--mode",
         help="Mode for ODB selection criteria",
-        choices=["ancestral", "basal", "latest", "none"],
+        choices=["ancestral", "basal", "latest"],
         action="append",
-        default=["none"],
+        default=[],
     )
     parser.add_argument("--debug", help="Debug mode.", action="store_true", default=False)
     parser.add_argument(
@@ -80,10 +80,10 @@ def parse_args(args=None):
     if not output_args.odb_version:
         parser.error("At least one --odb_version must be specified.")
 
-    if all(["ancestral", "latest"]) in output_args.mode:
+    if "ancestral" in output_args.mode and "latest" in output_args.mode:
         parser.error("Cannot use 'ancestral' and 'latest' at the same time.")
 
-    if not output_args.mode and not output_args.specified_lineages:
+    if not output_args.mode and not output_args.extra_lineages:
         parser.error("Must have either modes or specified lineages.")
 
     return output_args

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -3,7 +3,6 @@
 import argparse
 import os
 import sys
-from collections.abc import Container
 from dataclasses import dataclass
 from pathlib import Path
 from string import Template
@@ -38,6 +37,12 @@ class BuscoDatabase:
         if not hasattr(self, "_lineage_names_dict"):
             self._lineage_names_dict = {lineage.lineage: lineage for lineage in self.lineages}
         return self._lineage_names_dict
+
+    def validate_and_get(self, name: str) -> BuscoLineage:
+        try:
+            return self.by_lineage()[name]
+        except KeyError:
+            raise ValueError(f"Lineage {name} not found in mapping file.")
 
 
 # A class to hold the selected ODB lineages and their classifications (ancestral, basal, latest, extra)
@@ -200,14 +205,14 @@ def get_odb(
         master_list.add_lineage(first_lin, "latest", odb_string)
 
     if "basal" in mode:
-        validate_lineage_names(lineage_db.by_lineage(), basal_lineages)
         for basal in basal_lineages:
-            master_list.add_lineage(lineage_db.by_lineage()[basal], "basal", odb_string)
+            lin = lineage_db.validate_and_get(basal)
+            master_list.add_lineage(lin, "basal", odb_string)
 
     if extra_lineages:
-        validate_lineage_names(lineage_db.by_lineage(), extra_lineages)
         for lineage in extra_lineages:
-            master_list.add_lineage(lineage_db.by_lineage()[lineage], "extra", odb_string)
+            lin = lineage_db.validate_and_get(lineage)
+            master_list.add_lineage(lin, "extra", odb_string)
 
     if debug:
         print(master_list)
@@ -287,15 +292,6 @@ def read_mapping_file(mapping_file: str) -> BuscoDatabase:
                 )
             )
     return BuscoDatabase(lineages=lineages)
-
-
-def validate_lineage_names(valid_names: Container[str], lineages: list[str]):
-    """
-    Validate that the lineage names in the mapping file are valid.
-    """
-    for lineage in lineages:
-        if lineage not in valid_names:
-            raise ValueError(f"Lineage {lineage} not found in mapping file.")
 
 
 def main(args=None):

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -94,7 +94,7 @@ def make_dir(path):
         os.makedirs(path, exist_ok=True)
 
 
-def get_http_request_json(url):
+def get_http_request_json(url: str):
     """
     Robust wrapper for requests.get()
     """
@@ -164,7 +164,7 @@ def get_odb(
     """
     odb_dict: dict[str, BuscoLineage] = get_lineage_data(taxid, lineage_tax_ids_dict)
 
-    master_list = dict()
+    master_list: dict[str, BuscoSelection] = dict()
 
     if "ancestral" in mode:
         master_list.update(
@@ -236,7 +236,7 @@ def print_out(lineage_list: dict[str, BuscoSelection], file_out: str, debug: boo
             fout.write(f"{line}\n")
 
 
-def validate_lineage(lineage: dict[str, BuscoLineage], lineages_path: str):
+def validate_lineage(lineage: dict[str, BuscoSelection], lineages_path: str):
     """
     Validate that the lineage exists in the lineage path.
     IF path is given, if not then we assume that the user want to run busco in ONLINE mode which means we can't validate local ODBs.
@@ -302,7 +302,7 @@ def main(args=None):
     args = parse_args(args)
 
     mapping_files = get_mapping_file(args.mapping_dir, args.odb_version, args.debug)
-    all_lineages = dict()
+    all_lineages: dict[str, BuscoSelection] = dict()
 
     for mapping_file, odb_version_string in mapping_files:
         mapping_data = read_mapping_file(mapping_file, odb_version_string)

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -34,19 +34,20 @@ def parse_args(args=None):
     description = "Get ODB database value using NCBI API and BUSCO configuration file"
 
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--taxid", help="TaxID for the species to retrieve ODBs for.", type=int)
+    parser.add_argument("--taxid", help="TaxID for the species to retrieve ODBs for.", type=int, required=True)
     parser.add_argument(
         "--odb_version",
         help="Version of ODB to use",
         choices=["odb10", "odb12", "odb12.2", "all"],
         action="append",
     )
-    parser.add_argument("--file_out", help="Output CSV file.")
+    parser.add_argument("--file_out", help="Output CSV file.", type=str, required=True)
     parser.add_argument("--odb_dir", help="Directory containing ODB files (Excluding the lineage subdirectory).")
     parser.add_argument(
         "--mapping_dir",
         help="Directory containing mapping files (BUSCO taxid to lineage mapping txt files).",
         type=str,
+        required=True,
     )
     parser.add_argument(
         "--mode",
@@ -75,6 +76,9 @@ def parse_args(args=None):
 
     # Quick input validation
     output_args = parser.parse_args(args)
+
+    if not output_args.odb_version:
+        parser.error("At least one --odb_version must be specified.")
 
     if all(["ancestral", "latest"]) in output_args.mode:
         parser.error("Cannot use 'ancestral' and 'latest' at the same time.")

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -48,12 +48,6 @@ class BuscoSelection:
     def add_lineage(self, lineage: BuscoLineage, classification: str, odb_string: str):
         self.selections.setdefault(f"{lineage.lineage}{odb_string}", classification)
 
-    def combine(self, other: "BuscoSelection"):
-        self.selections.update(other.selections)
-
-    def __iter__(self):
-        return iter(self.selections.items())
-
 
 def parse_args(args=None):
     description = "Get ODB database value using NCBI API and BUSCO configuration file"
@@ -227,7 +221,7 @@ def print_out(lineage_list: BuscoSelection, file_out: str, debug: bool):
     One line per lineage
     """
     with open(file_out, "w") as fout:
-        for odb_string, classification in lineage_list:
+        for odb_string, classification in lineage_list.selections.items():
             line = f"{odb_string},{classification}"
             if debug:
                 print(line)
@@ -241,7 +235,7 @@ def check_offline_availability(selected_buscos: BuscoSelection, lineages_path: s
     IF path is given, if not then we assume that the user want to run busco in ONLINE mode which means we can't validate local ODBs.
     """
     error_lineages = []
-    for odb_string, classification in selected_buscos:
+    for odb_string in selected_buscos.selections:
         if not os.path.exists(os.path.join(lineages_path, "lineages", odb_string)):
             error_lineages.append(odb_string)
 
@@ -323,7 +317,7 @@ def main(args=None):
             args.debug,
         )
 
-        all_lineages.combine(lineage_list)
+        all_lineages.selections.update(lineage_list.selections)
 
     if args.odb_dir:
         check_offline_availability(all_lineages, args.odb_dir)

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -186,7 +186,10 @@ def get_odb(
     """
     Read the mapping between the BUSCO lineages and their taxon_id
     """
-    ancestral_lineages = get_lineage_data(taxid, lineage_db.by_taxid())
+    if "ancestral" in mode or "latest" in mode:
+        ancestral_lineages = get_lineage_data(taxid, lineage_db.by_taxid())
+    else:
+        ancestral_lineages = []
 
     master_list = BuscoSelection()
 

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -262,6 +262,9 @@ def get_mapping_file(mapping_dir: str, odb_version: list, debug: bool) -> list[t
     files = [str(file) for file in Path(mapping_dir).glob("*.txt")]
     for odb in odb_version_list:
         # There is no odb12.2 mapping file as of 5th June 2026
+        # If a file is introduced we may have to change this logic to avoid matching
+        # "mapping_taxids-busco_dataset_name.eukaryota_odb12.2025-01-15.txt" by accident
+        # when looking for odb12.2 files
         odb_placeholder = "odb12" if odb == "odb12.2" else odb
         for file in files:
             if odb_placeholder in file:

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from string import Template
 
@@ -23,10 +23,16 @@ class BuscoLineage:
     lineage: str
 
 
+# A structure to hold the selected ODB lineages and their classifications (ancestral, basal, latest, extra)
+type BuscoSelection = dict[str, str]
+
+
 # All entries from a mapping file, with helper functions to index them
 @dataclass
 class BuscoDatabase:
+    odb_string: str
     lineages: list[BuscoLineage]
+    selection: BuscoSelection = field(default_factory=dict)
 
     def by_taxid(self) -> dict[int, BuscoLineage]:
         if not hasattr(self, "_lineage_tax_ids_dict"):
@@ -44,12 +50,9 @@ class BuscoDatabase:
         except KeyError:
             raise ValueError(f"Lineage {name} not found in mapping file.")
 
-
-# A class to hold the selected ODB lineages and their classifications (ancestral, basal, latest, extra)
-class BuscoSelection(dict[str, str]):
     # Convenient method to add a lineage to the selection
-    def add_lineage(self, lineage: BuscoLineage, classification: str, odb_string: str):
-        self.setdefault(f"{lineage.lineage}{odb_string}", classification)
+    def select_lineage(self, lineage: BuscoLineage, classification: str):
+        self.selection.setdefault(f"{lineage.lineage}{self.odb_string}", classification)
 
 
 def parse_args(args=None):
@@ -162,14 +165,13 @@ def get_lineage_data(taxid: int, busco_db: BuscoDatabase) -> list[BuscoLineage]:
             sys.exit(1)
 
 
-def get_odb(
+def select_odb(
     mode: list[str],
     taxid: int,
     basal_lineages: list[str],
     extra_lineages: list[str],
     busco_db: BuscoDatabase,
-    odb_string: str,
-) -> BuscoSelection:
+):
     """
     Read the mapping between the BUSCO lineages and their taxon_id
     """
@@ -177,8 +179,6 @@ def get_odb(
         ancestral_lineages = get_lineage_data(taxid, busco_db)
     else:
         ancestral_lineages = []
-
-    master_list = BuscoSelection()
 
     if "ancestral" in mode:
         for i, lineage in enumerate(ancestral_lineages):
@@ -188,22 +188,20 @@ def get_odb(
                 classification = "basal"
             else:
                 classification = "ancestral"
-            master_list.add_lineage(lineage, classification, odb_string)
+            busco_db.select_lineage(lineage, classification)
 
     if "latest" in mode:
-        master_list.add_lineage(ancestral_lineages[0], "latest", odb_string)
+        busco_db.select_lineage(ancestral_lineages[0], "latest")
 
     if "basal" in mode:
         for basal in basal_lineages:
             lin = busco_db.validate_and_get(basal)
-            master_list.add_lineage(lin, "basal", odb_string)
+            busco_db.select_lineage(lin, "basal")
 
     if extra_lineages:
         for lineage in extra_lineages:
             lin = busco_db.validate_and_get(lineage)
-            master_list.add_lineage(lin, "extra", odb_string)
-
-    return master_list
+            busco_db.select_lineage(lin, "extra")
 
 
 def print_out(lineage_list: BuscoSelection, file_out: str, debug: bool):
@@ -262,7 +260,7 @@ def get_mapping_file(mapping_dir: str, odb_version: list, debug: bool) -> list[t
     return mapping_files
 
 
-def read_mapping_file(mapping_file: str) -> BuscoDatabase:
+def read_mapping_file(mapping_file: str, odb_string: str) -> BuscoDatabase:
     """
     Read the mapping file and return the database object containing
     the list of taxids and lineage names.
@@ -277,31 +275,30 @@ def read_mapping_file(mapping_file: str) -> BuscoDatabase:
                     lineage=arr[1],
                 )
             )
-    return BuscoDatabase(lineages=lineages)
+    return BuscoDatabase(odb_string=odb_string, lineages=lineages)
 
 
 def main(args=None):
     args = parse_args(args)
 
     mapping_files = get_mapping_file(args.mapping_dir, args.odb_version, args.debug)
-    all_lineages = BuscoSelection()
+    all_lineages: BuscoSelection = {}
 
     for mapping_file, odb_version_string in mapping_files:
-        mapping_data = read_mapping_file(mapping_file)
+        mapping_data = read_mapping_file(mapping_file, odb_version_string)
 
-        lineage_list = get_odb(
+        select_odb(
             args.mode,
             args.taxid,
             args.basal_lineages,
             args.extra_lineages,
             mapping_data,
-            odb_version_string,
         )
 
         if args.debug:
-            print(odb_version_string, lineage_list)
+            print(odb_version_string, mapping_data.selection)
 
-        all_lineages.update(lineage_list)
+        all_lineages.update(mapping_data.selection)
 
     if args.odb_dir:
         check_offline_availability(all_lineages, args.odb_dir)

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -236,7 +236,7 @@ def print_out(lineage_list: dict[str, BuscoSelection], file_out: str, debug: boo
             fout.write(f"{line}\n")
 
 
-def validate_lineage(lineage: dict[str, BuscoSelection], lineages_path: str):
+def check_offline_availability(lineage: dict[str, BuscoSelection], lineages_path: str):
     """
     Validate that the lineage exists in the lineage path.
     IF path is given, if not then we assume that the user want to run busco in ONLINE mode which means we can't validate local ODBs.
@@ -317,7 +317,7 @@ def main(args=None):
         all_lineages.update(lineage_list.items())
 
     if args.odb_dir:
-        validate_lineage(all_lineages, args.odb_dir)
+        check_offline_availability(all_lineages, args.odb_dir)
     else:
         print("Skipping validation, odb_dir not provided (indicates your probably wanting busco to run in online mode)")
 

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -131,32 +131,32 @@ def get_http_request_json(url: str):
     return response.json()
 
 
-def goat_api_call(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> dict[str, BuscoLineage]:
+def goat_api_call(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> list[BuscoLineage]:
     response = get_http_request_json(GOAT_API.substitute(taxid=taxid))
     data = response["results"][0]["result"]["lineage"]
     query_tax_list = [int(taxid["taxon_id"]) for taxid in data]
 
-    return {
-        lineage_tax_ids_dict[taxon_id].lineage: lineage_tax_ids_dict[taxon_id]
+    return [
+        lineage_tax_ids_dict[taxon_id]
         for taxon_id in query_tax_list
         if taxon_id in lineage_tax_ids_dict
-    }
+    ]
 
 
-def ena_api_call(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> dict[str, BuscoLineage]:
+def ena_api_call(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> list[BuscoLineage]:
     ena_response = get_http_request_json(ENA_API.substitute(taxid=taxid))
     lineage_name = [lineage.lower() for lineage in ena_response["lineage"].split(";")]
     odb_lineage_names = [tax_lin.lineage for tax_lin in lineage_tax_ids_dict.values()]
 
-    return {
-        lineage_tax_ids_dict[y.taxid].lineage: lineage_tax_ids_dict[y.taxid]
+    return [
+        lineage_tax_ids_dict[y.taxid]
         for i in set(lineage_name + odb_lineage_names)
-        for _x, y in lineage_tax_ids_dict.items()
+        for y in lineage_tax_ids_dict.values()
         if y.lineage == i
-    }
+    ]
 
 
-def get_lineage_data(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> dict[str, BuscoLineage]:
+def get_lineage_data(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> list[BuscoLineage]:
     """
     Get lineage data for a given taxid
     """
@@ -186,14 +186,13 @@ def get_odb(
     """
     Read the mapping between the BUSCO lineages and their taxon_id
     """
-    odb_dict: dict[str, BuscoLineage] = get_lineage_data(taxid, lineage_db.by_taxid())
-    first_lin = odb_dict[list(odb_dict)[0]]
+    ancestral_lineages = get_lineage_data(taxid, lineage_db.by_taxid())
 
     master_list = BuscoSelection()
 
     if "ancestral" in mode:
-        for lineage in odb_dict.values():
-            if lineage == first_lin:
+        for i, lineage in enumerate(ancestral_lineages):
+            if i == 0:
                 classification = "latest"
             elif "basal" in mode and lineage.lineage in basal_lineages:
                 classification = "basal"
@@ -202,7 +201,7 @@ def get_odb(
             master_list.add_lineage(lineage, classification, odb_string)
 
     if "latest" in mode:
-        master_list.add_lineage(first_lin, "latest", odb_string)
+        master_list.add_lineage(ancestral_lineages[0], "latest", odb_string)
 
     if "basal" in mode:
         for basal in basal_lineages:

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+from collections.abc import Container
 from dataclasses import dataclass
 from pathlib import Path
 from string import Template
@@ -16,18 +17,42 @@ GOAT_API = Template(
 ENA_API = Template("https://www.ebi.ac.uk/ena/taxonomy/rest/v2/tax-id/${taxid}?binomialOnly=false")
 
 
-@dataclass
+# A single entry from a mapping file
+@dataclass(frozen=True)
 class BuscoLineage:
     taxid: int
     lineage: str
-    odb_string: str
 
 
+# All entries from a mapping file, with helper functions to index them
 @dataclass
+class BuscoDatabase:
+    lineages: list[BuscoLineage]
+
+    def by_taxid(self) -> dict[int, BuscoLineage]:
+        if not hasattr(self, "_lineage_tax_ids_dict"):
+            self._lineage_tax_ids_dict = {lineage.taxid: lineage for lineage in self.lineages}
+        return self._lineage_tax_ids_dict
+
+    def by_lineage(self) -> dict[str, BuscoLineage]:
+        if not hasattr(self, "_lineage_names_dict"):
+            self._lineage_names_dict = {lineage.lineage: lineage for lineage in self.lineages}
+        return self._lineage_names_dict
+
+
+# A class to hold the selected ODB lineages and their classifications (ancestral, basal, latest, extra)
 class BuscoSelection:
-    odb_string: str
-    taxid: int
-    classification: str
+    def __init__(self):
+        self.selections: dict[str, str] = dict()
+
+    def add_lineage(self, lineage: BuscoLineage, classification: str, odb_string: str):
+        self.selections.setdefault(f"{lineage.lineage}{odb_string}", classification)
+
+    def combine(self, other: "BuscoSelection"):
+        self.selections.update(other.selections)
+
+    def __iter__(self):
+        return iter(self.selections.items())
 
 
 def parse_args(args=None):
@@ -155,66 +180,40 @@ def get_odb(
     taxid: int,
     basal_lineages: list[str],
     extra_lineages: list[str],
-    lineage_tax_ids_dict: dict[int, BuscoLineage],
+    lineage_db: BuscoDatabase,
     odb_string: str,
     debug: bool,
-) -> dict[str, BuscoSelection]:
+) -> BuscoSelection:
     """
     Read the mapping between the BUSCO lineages and their taxon_id
     """
-    odb_dict: dict[str, BuscoLineage] = get_lineage_data(taxid, lineage_tax_ids_dict)
+    odb_dict: dict[str, BuscoLineage] = get_lineage_data(taxid, lineage_db.by_taxid())
 
-    master_list: dict[str, BuscoSelection] = dict()
+    master_list = BuscoSelection()
 
     if "ancestral" in mode:
-        master_list.update(
-            {
-                f"{odb_dict[lineage].taxid}_{lineage}{odb_string}": BuscoSelection(
-                    odb_string=lineage + odb_string,
-                    taxid=odb_dict[lineage].taxid,
-                    classification=(
-                        "latest"
-                        if lineage == list(odb_dict)[0]
-                        else "ancestral"
-                        if "basal" in mode and lineage not in basal_lineages
-                        else "basal"
-                        if "basal" in mode and lineage in basal_lineages
-                        else "ancestral"
-                    ),
-                )
-                for lineage in odb_dict
-            }
-        )
+        for lineage in odb_dict.values():
+            if lineage == odb_dict[list(odb_dict)[0]]:
+                classification = "latest"
+            elif "basal" in mode and lineage.lineage in basal_lineages:
+                classification = "basal"
+            else:
+                classification = "ancestral"
+            master_list.add_lineage(lineage, classification, odb_string)
 
     if "latest" in mode:
-        first_key = list(odb_dict)[0]
-        master_list[f"{odb_dict[first_key].taxid}_{odb_dict[first_key].lineage}{odb_string}"] = BuscoSelection(
-            odb_string=odb_dict[first_key].lineage + odb_string,
-            taxid=odb_dict[first_key].taxid,
-            classification="ancestral",
-        )
+        first_lin = odb_dict[list(odb_dict)[0]]
+        master_list.add_lineage(first_lin, "latest", odb_string)
 
     if "basal" in mode:
+        validate_lineage_names(lineage_db.by_lineage(), basal_lineages)
         for basal in basal_lineages:
-            for x, y in lineage_tax_ids_dict.items():
-                if basal == y.lineage:
-                    if f"{y.taxid}_{basal}{odb_string}" not in master_list.keys():
-                        master_list[f"{y.taxid}_{basal}{odb_string}"] = BuscoSelection(
-                            odb_string=basal + odb_string,
-                            taxid=y.taxid,
-                            classification="basal",
-                        )
+            master_list.add_lineage(lineage_db.by_lineage()[basal], "basal", odb_string)
 
     if extra_lineages:
+        validate_lineage_names(lineage_db.by_lineage(), extra_lineages)
         for lineage in extra_lineages:
-            for x, y in lineage_tax_ids_dict.items():
-                if lineage == y.lineage:
-                    if f"{y.taxid}_{lineage}{odb_string}" not in master_list.keys():
-                        master_list[f"{y.taxid}_{lineage}{odb_string}"] = BuscoSelection(
-                            odb_string=lineage + odb_string,
-                            taxid=y.taxid,
-                            classification="extra",
-                        )
+            master_list.add_lineage(lineage_db.by_lineage()[lineage], "extra", odb_string)
 
     if debug:
         print(master_list)
@@ -222,29 +221,29 @@ def get_odb(
     return master_list
 
 
-def print_out(lineage_list: dict[str, BuscoSelection], file_out: str, debug: bool):
+def print_out(lineage_list: BuscoSelection, file_out: str, debug: bool):
     """
     Print the lineage list to the output file.
     One line per lineage
     """
     with open(file_out, "w") as fout:
-        for item_code, data in lineage_list.items():
-            line = f"{data.odb_string},{data.classification}"
+        for odb_string, classification in lineage_list:
+            line = f"{odb_string},{classification}"
             if debug:
                 print(line)
 
             fout.write(f"{line}\n")
 
 
-def check_offline_availability(lineage: dict[str, BuscoSelection], lineages_path: str):
+def check_offline_availability(selected_buscos: BuscoSelection, lineages_path: str):
     """
     Validate that the lineage exists in the lineage path.
     IF path is given, if not then we assume that the user want to run busco in ONLINE mode which means we can't validate local ODBs.
     """
     error_lineages = []
-    for data in lineage.values():
-        if not os.path.exists(os.path.join(lineages_path, "lineages", data.odb_string)):
-            error_lineages.append(data.odb_string)
+    for odb_string, classification in selected_buscos:
+        if not os.path.exists(os.path.join(lineages_path, "lineages", odb_string)):
+            error_lineages.append(odb_string)
 
     if len(error_lineages) > 0:
         raise FileNotFoundError(f"Lineages {error_lineages} not found in {lineages_path}")
@@ -278,31 +277,41 @@ def get_mapping_file(mapping_dir: str, odb_version: list, debug: bool) -> list[t
     return mapping_files
 
 
-def read_mapping_file(mapping_file: str, odb_string: str) -> dict[int, BuscoLineage]:
+def read_mapping_file(mapping_file: str) -> BuscoDatabase:
     """
-    Read the mapping file and return a dictionary mapping lineage taxids
-    to odb_dataset data.
+    Read the mapping file and return the database object containing
+    the list of taxids and lineage names.
     """
-    lineage_tax_ids_dict = {}
+    lineages = []
     with open(mapping_file) as file_in:
         for line in file_in:
             arr = line.split()
-            lineage_tax_ids_dict[int(arr[0])] = BuscoLineage(
-                taxid=int(arr[0]),
-                lineage=arr[1],
-                odb_string=odb_string,
+            lineages.append(
+                BuscoLineage(
+                    taxid=int(arr[0]),
+                    lineage=arr[1],
+                )
             )
-    return lineage_tax_ids_dict
+    return BuscoDatabase(lineages=lineages)
+
+
+def validate_lineage_names(valid_names: Container[str], lineages: list[str]):
+    """
+    Validate that the lineage names in the mapping file are valid.
+    """
+    for lineage in lineages:
+        if lineage not in valid_names:
+            raise ValueError(f"Lineage {lineage} not found in mapping file.")
 
 
 def main(args=None):
     args = parse_args(args)
 
     mapping_files = get_mapping_file(args.mapping_dir, args.odb_version, args.debug)
-    all_lineages: dict[str, BuscoSelection] = dict()
+    all_lineages = BuscoSelection()
 
     for mapping_file, odb_version_string in mapping_files:
-        mapping_data = read_mapping_file(mapping_file, odb_version_string)
+        mapping_data = read_mapping_file(mapping_file)
 
         lineage_list = get_odb(
             args.mode,
@@ -314,7 +323,7 @@ def main(args=None):
             args.debug,
         )
 
-        all_lineages.update(lineage_list.items())
+        all_lineages.combine(lineage_list)
 
     if args.odb_dir:
         check_offline_availability(all_lineages, args.odb_dir)

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -46,12 +46,10 @@ class BuscoDatabase:
 
 
 # A class to hold the selected ODB lineages and their classifications (ancestral, basal, latest, extra)
-class BuscoSelection:
-    def __init__(self):
-        self.selections: dict[str, str] = dict()
-
+class BuscoSelection(dict[str, str]):
+    # Convenient method to add a lineage to the selection
     def add_lineage(self, lineage: BuscoLineage, classification: str, odb_string: str):
-        self.selections.setdefault(f"{lineage.lineage}{odb_string}", classification)
+        self.setdefault(f"{lineage.lineage}{odb_string}", classification)
 
 
 def parse_args(args=None):
@@ -214,7 +212,7 @@ def print_out(lineage_list: BuscoSelection, file_out: str, debug: bool):
     One line per lineage
     """
     with open(file_out, "w") as fout:
-        for odb_string, classification in lineage_list.selections.items():
+        for odb_string, classification in lineage_list.items():
             line = f"{odb_string},{classification}"
             if debug:
                 print(line)
@@ -228,7 +226,7 @@ def check_offline_availability(selected_buscos: BuscoSelection, lineages_path: s
     IF path is given, if not then we assume that the user want to run busco in ONLINE mode which means we can't validate local ODBs.
     """
     error_lineages = []
-    for odb_string in selected_buscos.selections:
+    for odb_string in selected_buscos:
         if not os.path.exists(os.path.join(lineages_path, "lineages", odb_string)):
             error_lineages.append(odb_string)
 
@@ -303,7 +301,7 @@ def main(args=None):
         if args.debug:
             print(odb_version_string, lineage_list)
 
-        all_lineages.selections.update(lineage_list.selections)
+        all_lineages.update(lineage_list)
 
     if args.odb_dir:
         check_offline_availability(all_lineages, args.odb_dir)

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -261,13 +261,15 @@ def get_mapping_file(mapping_dir: str, odb_version: list, debug: bool) -> list[t
     mapping_files = []
     odb_version_list = ["odb10", "odb12", "odb12.2"] if "all" in odb_version else odb_version
 
-    for file in Path(mapping_dir).glob("*.txt"):
-        for odb in odb_version_list:
-            # There is no odb12.2 mapping file as of 5th June 2026
-            odb_placeholder = "odb12" if odb == "odb12.2" else odb
-            if f"{odb_placeholder}" in str(file):
-                (print("Found", file) if debug else None)
-                mapping_files.append((str(file), f"_{odb}"))
+    files = [str(file) for file in Path(mapping_dir).glob("*.txt")]
+    for odb in odb_version_list:
+        # There is no odb12.2 mapping file as of 5th June 2026
+        odb_placeholder = "odb12" if odb == "odb12.2" else odb
+        for file in files:
+            if odb_placeholder in file:
+                if debug:
+                    print("Found", file)
+                mapping_files.append((file, f"_{odb}"))
 
     if len(mapping_files) == 0:
         raise FileNotFoundError(f"No mapping files found in {mapping_dir} for odb version(s) {odb_version}")

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -181,7 +181,6 @@ def get_odb(
     extra_lineages: list[str],
     lineage_db: BuscoDatabase,
     odb_string: str,
-    debug: bool,
 ) -> BuscoSelection:
     """
     Read the mapping between the BUSCO lineages and their taxon_id
@@ -215,9 +214,6 @@ def get_odb(
         for lineage in extra_lineages:
             lin = lineage_db.validate_and_get(lineage)
             master_list.add_lineage(lin, "extra", odb_string)
-
-    if debug:
-        print(master_list)
 
     return master_list
 
@@ -312,8 +308,10 @@ def main(args=None):
             args.extra_lineages,
             mapping_data,
             odb_version_string,
-            args.debug,
         )
+
+        if args.debug:
+            print(odb_version_string, lineage_list)
 
         all_lineages.selections.update(lineage_list.selections)
 

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -187,12 +187,13 @@ def get_odb(
     Read the mapping between the BUSCO lineages and their taxon_id
     """
     odb_dict: dict[str, BuscoLineage] = get_lineage_data(taxid, lineage_db.by_taxid())
+    first_lin = odb_dict[list(odb_dict)[0]]
 
     master_list = BuscoSelection()
 
     if "ancestral" in mode:
         for lineage in odb_dict.values():
-            if lineage == odb_dict[list(odb_dict)[0]]:
+            if lineage == first_lin:
                 classification = "latest"
             elif "basal" in mode and lineage.lineage in basal_lineages:
                 classification = "basal"
@@ -201,7 +202,6 @@ def get_odb(
             master_list.add_lineage(lineage, classification, odb_string)
 
     if "latest" in mode:
-        first_lin = odb_dict[list(odb_dict)[0]]
         master_list.add_lineage(first_lin, "latest", odb_string)
 
     if "basal" in mode:

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -136,36 +136,26 @@ def goat_api_call(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> 
     data = response["results"][0]["result"]["lineage"]
     query_tax_list = [int(taxid["taxon_id"]) for taxid in data]
 
-    return [
-        lineage_tax_ids_dict[taxon_id]
-        for taxon_id in query_tax_list
-        if taxon_id in lineage_tax_ids_dict
-    ]
+    return [lineage_tax_ids_dict[taxon_id] for taxon_id in query_tax_list if taxon_id in lineage_tax_ids_dict]
 
 
-def ena_api_call(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> list[BuscoLineage]:
+def ena_api_call(taxid: int, lineage_names_dict: dict[str, BuscoLineage]) -> list[BuscoLineage]:
     ena_response = get_http_request_json(ENA_API.substitute(taxid=taxid))
-    lineage_name = [lineage.lower() for lineage in ena_response["lineage"].split(";")]
-    odb_lineage_names = [tax_lin.lineage for tax_lin in lineage_tax_ids_dict.values()]
+    lineage_names = [lineage.strip().lower() for lineage in ena_response["lineage"].split(";")]
 
-    return [
-        lineage_tax_ids_dict[y.taxid]
-        for i in set(lineage_name + odb_lineage_names)
-        for y in lineage_tax_ids_dict.values()
-        if y.lineage == i
-    ]
+    return [lineage_names_dict[name] for name in reversed(lineage_names) if name in lineage_names_dict]
 
 
-def get_lineage_data(taxid: int, lineage_tax_ids_dict: dict[int, BuscoLineage]) -> list[BuscoLineage]:
+def get_lineage_data(taxid: int, busco_db: BuscoDatabase) -> list[BuscoLineage]:
     """
     Get lineage data for a given taxid
     """
     try:
-        return goat_api_call(taxid, lineage_tax_ids_dict)
+        return goat_api_call(taxid, busco_db.by_taxid())
     except (requests.RequestException, KeyError, IndexError) as e:
         print(f"Warning: GOAT API call failed ({e}), falling back to ENA API", file=sys.stderr)
         try:
-            return ena_api_call(taxid, lineage_tax_ids_dict)
+            return ena_api_call(taxid, busco_db.by_lineage())
         except (requests.RequestException, KeyError, IndexError) as ena_error:
             print(
                 f"Error: Both GOAT and ENA servers could not be contacted. GOAT error: {e}. ENA error: {ena_error}",
@@ -179,14 +169,14 @@ def get_odb(
     taxid: int,
     basal_lineages: list[str],
     extra_lineages: list[str],
-    lineage_db: BuscoDatabase,
+    busco_db: BuscoDatabase,
     odb_string: str,
 ) -> BuscoSelection:
     """
     Read the mapping between the BUSCO lineages and their taxon_id
     """
     if "ancestral" in mode or "latest" in mode:
-        ancestral_lineages = get_lineage_data(taxid, lineage_db.by_taxid())
+        ancestral_lineages = get_lineage_data(taxid, busco_db)
     else:
         ancestral_lineages = []
 
@@ -207,12 +197,12 @@ def get_odb(
 
     if "basal" in mode:
         for basal in basal_lineages:
-            lin = lineage_db.validate_and_get(basal)
+            lin = busco_db.validate_and_get(basal)
             master_list.add_lineage(lin, "basal", odb_string)
 
     if extra_lineages:
         for lineage in extra_lineages:
-            lin = lineage_db.validate_and_get(lineage)
+            lin = busco_db.validate_and_get(lineage)
             master_list.add_lineage(lin, "extra", odb_string)
 
     return master_list

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/resources/usr/bin/get_odbs.py
@@ -243,14 +243,8 @@ def validate_lineage(lineage: dict[str, BuscoSelection], lineages_path: str):
     """
     error_lineages = []
     for data in lineage.values():
-        if lineages_path:
-            error_lineages.append(data.odb_string) if not os.path.exists(
-                os.path.join(lineages_path, "lineages", data.odb_string)
-            ) else None
-        else:
-            print(
-                f"Skipping validation of {data.odb_string}, odb_dir not provided (indicates your probably wanting busco to run in online mode)"
-            )
+        if not os.path.exists(os.path.join(lineages_path, "lineages", data.odb_string)):
+            error_lineages.append(data.odb_string)
 
     if len(error_lineages) > 0:
         raise FileNotFoundError(f"Lineages {error_lineages} not found in {lineages_path}")
@@ -319,7 +313,11 @@ def main(args=None):
 
         all_lineages.update(lineage_list.items())
 
-    validate_lineage(all_lineages, args.odb_dir)
+    if args.odb_dir:
+        validate_lineage(all_lineages, args.odb_dir)
+    else:
+        print("Skipping validation, odb_dir not provided (indicates your probably wanting busco to run in online mode)")
+
     make_dir(os.path.dirname(args.file_out))
     print_out(all_lineages, args.file_out, args.debug or args.print_output)
 

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/basal_and_mammalia.config
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/basal_and_mammalia.config
@@ -2,6 +2,6 @@ nextflow.enable.moduleBinaries = true
 
 process {
     withName: API_SCRIPTS_GET_LINEAGE_ODBS {
-        ext.args = { "--odb_version odb10 --mode basal --print_output" }
+        ext.args = { "--odb_version odb10 --mode basal" }
     }
 }

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/main.nf.test
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/main.nf.test
@@ -71,9 +71,13 @@ nextflow_process {
         }
 
         then {
+            def csv_object = path(process.out.csv[0][1]).csv(header: false)
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    csv_object.rows,
+                ).match() }
             )
         }
     }
@@ -114,9 +118,13 @@ nextflow_process {
         }
 
         then {
+            def csv_object = path(process.out.csv[0][1]).csv(header: false)
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    csv_object.rows,
+                ).match() }
             )
         }
     }

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/main.nf.test.snap
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/main.nf.test.snap
@@ -135,7 +135,7 @@
                         {
                             "id": "GCA_000001405.15"
                         },
-                        "GCA_000001405.15.busco_odb.csv:md5,da556c782e4d71c718da167d450a86c5"
+                        "GCA_000001405.15.busco_odb.csv:md5,8bb5cfd443a2a744fa3699bd7b14ab78"
                     ]
                 ],
                 "1": [
@@ -157,7 +157,7 @@
                         {
                             "id": "GCA_000001405.15"
                         },
-                        "GCA_000001405.15.busco_odb.csv:md5,da556c782e4d71c718da167d450a86c5"
+                        "GCA_000001405.15.busco_odb.csv:md5,8bb5cfd443a2a744fa3699bd7b14ab78"
                     ]
                 ],
                 "versions_get_odb": [
@@ -176,38 +176,6 @@
                 ]
             },
             [
-                {
-                    "C0": "primates_odb12",
-                    "C1": "latest"
-                },
-                {
-                    "C0": "euarchontoglires_odb12",
-                    "C1": "ancestral"
-                },
-                {
-                    "C0": "eutheria_odb12",
-                    "C1": "ancestral"
-                },
-                {
-                    "C0": "mammalia_odb12",
-                    "C1": "ancestral"
-                },
-                {
-                    "C0": "tetrapoda_odb12",
-                    "C1": "ancestral"
-                },
-                {
-                    "C0": "vertebrata_odb12",
-                    "C1": "ancestral"
-                },
-                {
-                    "C0": "metazoa_odb12",
-                    "C1": "ancestral"
-                },
-                {
-                    "C0": "eukaryota_odb12",
-                    "C1": "ancestral"
-                },
                 {
                     "C0": "primates_odb10",
                     "C1": "latest"
@@ -238,6 +206,38 @@
                 },
                 {
                     "C0": "eukaryota_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "primates_odb12",
+                    "C1": "latest"
+                },
+                {
+                    "C0": "euarchontoglires_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "eutheria_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "mammalia_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "tetrapoda_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "vertebrata_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "metazoa_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "eukaryota_odb12",
                     "C1": "ancestral"
                 }
             ]

--- a/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/main.nf.test.snap
+++ b/modules/sanger-tol/api_scripts/get_lineage_odbs/tests/main.nf.test.snap
@@ -46,9 +46,27 @@
                         "3.14.5"
                     ]
                 ]
-            }
+            },
+            [
+                {
+                    "C0": "bacteria_odb10",
+                    "C1": "basal"
+                },
+                {
+                    "C0": "archaea_odb10",
+                    "C1": "basal"
+                },
+                {
+                    "C0": "eukaryota_odb10",
+                    "C1": "basal"
+                },
+                {
+                    "C0": "mammalia_odb10",
+                    "C1": "extra"
+                }
+            ]
         ],
-        "timestamp": "2026-06-10T12:13:07.469581286",
+        "timestamp": "2026-06-10T18:24:14.930479239",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -156,9 +174,75 @@
                         "3.14.5"
                     ]
                 ]
-            }
+            },
+            [
+                {
+                    "C0": "primates_odb12",
+                    "C1": "latest"
+                },
+                {
+                    "C0": "euarchontoglires_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "eutheria_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "mammalia_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "tetrapoda_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "vertebrata_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "metazoa_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "eukaryota_odb12",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "primates_odb10",
+                    "C1": "latest"
+                },
+                {
+                    "C0": "euarchontoglires_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "eutheria_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "mammalia_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "tetrapoda_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "vertebrata_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "metazoa_odb10",
+                    "C1": "ancestral"
+                },
+                {
+                    "C0": "eukaryota_odb10",
+                    "C1": "ancestral"
+                }
+            ]
         ],
-        "timestamp": "2026-06-10T12:13:15.595958669",
+        "timestamp": "2026-06-10T18:24:23.374429762",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/nf-test.config
+++ b/nf-test.config
@@ -14,6 +14,7 @@ config {
     // load the necessary plugins
     plugins {
         load "nft-bam@0.6.0"
+        load "nft-csv@0.1.0"
         load "nft-utils@0.0.8"
         load "nft-vcf@1.0.7"
     }


### PR DESCRIPTION
Making another PR to not overload the previous one.

To make it easier to review the output of the script, I propose using [nft-csv](https://github.com/lukfor/nft-csv) to load the content directly in the snapshot.

That's one of the reason I ended up running the CLI myself. As a reviewer I couldn't interpret the MD5 checksums and understand if the CSV were actually correct or not.

Edit: I tweaked `get_mapping_file` to return the filenames in a deterministic order. From https://docs.python.org/3/library/glob.html
> The pathnames are returned in no particular order. If you need a specific order, sort the results.

Here, I don't _sort_ but flipped the `for` loops so that the files are returned in the same order as `odb_version_list`

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] If you've added or modified a sub-workflow, ensure all sub-analyses are emitted as individual channels. Outputs may also be collected together by analysis type or input sample, for instance to support downstream analysis or publishing.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
