### PR TITLE
Simplification of the BUSCO modules/sub-workflow parameters

### DIFF
--- a/modules/sanger-tol/apiscripts/getlineageodbs/main.nf
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/main.nf
@@ -11,7 +11,6 @@ process APISCRIPTS_GETLINEAGEODBS {
     tuple val(meta), path(fasta)
     path(odb_directory)
     path(mapping_directory)
-    val(specified_lineages)
 
     output:
     tuple val(meta), path("*.busco_odb.csv"), emit: csv
@@ -26,14 +25,12 @@ process APISCRIPTS_GETLINEAGEODBS {
     def prefix          = task.ext.prefix       ?: "${meta.id}"
     def odb_dir_path    = odb_directory         ? "--odb_dir ${odb_directory}"          : ""
     def mapping_dir_path= mapping_directory     ? "--mapping_dir ${mapping_directory}"  : ""
-    formatted_lineages  = specified_lineages    ? "--extra_lineages " + specified_lineages.tokenize(',').join(' ') : ""
     """
     get_odbs.py \\
         ${odb_dir_path} \\
         ${mapping_dir_path} \\
         --file_out ${prefix}.busco_odb.csv \\
-        ${args} \\
-        ${formatted_lineages}
+        ${args}
     """
 
     stub:

--- a/modules/sanger-tol/apiscripts/getlineageodbs/main.nf
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/main.nf
@@ -11,7 +11,6 @@ process APISCRIPTS_GETLINEAGEODBS {
     tuple val(meta), path(fasta)
     path(odb_directory)
     path(mapping_directory)
-    val(taxid)
     val(specified_lineages)
 
     output:
@@ -25,13 +24,11 @@ process APISCRIPTS_GETLINEAGEODBS {
     script:
     def args            = task.ext.args         ?: ''
     def prefix          = task.ext.prefix       ?: "${meta.id}"
-    def taxid_str       = taxid                 ? "--taxid ${taxid}"                    : ""
     def odb_dir_path    = odb_directory         ? "--odb_dir ${odb_directory}"          : ""
     def mapping_dir_path= mapping_directory     ? "--mapping_dir ${mapping_directory}"  : ""
     formatted_lineages  = specified_lineages    ? "--extra_lineages " + specified_lineages.tokenize(',').join(' ') : ""
     """
     get_odbs.py \\
-        ${taxid_str} \\
         ${odb_dir_path} \\
         ${mapping_dir_path} \\
         --file_out ${prefix}.busco_odb.csv \\

--- a/modules/sanger-tol/apiscripts/getlineageodbs/main.nf
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/main.nf
@@ -25,12 +25,13 @@ process APISCRIPTS_GETLINEAGEODBS {
     script:
     def args            = task.ext.args         ?: ''
     def prefix          = task.ext.prefix       ?: "${meta.id}"
+    def taxid_str       = taxid                 ? "--taxid ${taxid}"                    : ""
     def odb_dir_path    = odb_directory         ? "--odb_dir ${odb_directory}"          : ""
     def mapping_dir_path= mapping_directory     ? "--mapping_dir ${mapping_directory}"  : ""
     formatted_lineages  = specified_lineages    ? "--extra_lineages " + specified_lineages.tokenize(',').join(' ') : ""
     """
     get_odbs.py \\
-        --taxid ${taxid} \\
+        ${taxid_str} \\
         ${odb_dir_path} \\
         ${mapping_dir_path} \\
         --file_out ${prefix}.busco_odb.csv \\

--- a/modules/sanger-tol/apiscripts/getlineageodbs/meta.yml
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/meta.yml
@@ -33,10 +33,6 @@ input:
   - mapping_directory:
       type: directory
       description: Directory containing the ODB lineage mapping data, these exist as txt files of taxid to lineage.
-  - taxid:
-      type: integer
-      description: Taxonomic ID of the assembly.
-      pattern: "^[0-9]+$"
   - specified_lineages:
       type: string
       description: CSV list of specifiied lineages by user.

--- a/modules/sanger-tol/apiscripts/getlineageodbs/meta.yml
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/meta.yml
@@ -33,9 +33,6 @@ input:
   - mapping_directory:
       type: directory
       description: Directory containing the ODB lineage mapping data, these exist as txt files of taxid to lineage.
-  - specified_lineages:
-      type: string
-      description: CSV list of specifiied lineages by user.
 output:
   csv:
     - - meta:

--- a/modules/sanger-tol/apiscripts/getlineageodbs/resources/usr/bin/get_odbs.py
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/resources/usr/bin/get_odbs.py
@@ -59,7 +59,7 @@ def parse_args(args=None):
     description = "Get ODB database value using NCBI API and BUSCO configuration file"
 
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--taxid", help="TaxID for the species to retrieve ODBs for.", type=int, required=True)
+    parser.add_argument("--taxid", help="TaxID for the species to retrieve ODBs for.", type=int)
     parser.add_argument(
         "--odb_version",
         help="Version of ODB to use",
@@ -107,6 +107,9 @@ def parse_args(args=None):
 
     if "ancestral" in output_args.mode and "latest" in output_args.mode:
         parser.error("Cannot use 'ancestral' and 'latest' at the same time.")
+
+    if ("ancestral" in output_args.mode or "latest" in output_args.mode) and not output_args.taxid:
+        parser.error("--taxid is required for the 'ancestral' and 'latest' modes.")
 
     if not output_args.mode and not output_args.extra_lineages:
         parser.error("Must have either modes or specified lineages.")

--- a/modules/sanger-tol/apiscripts/getlineageodbs/tests/all_ancestral_odb.config
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/tests/all_ancestral_odb.config
@@ -2,6 +2,6 @@ nextflow.enable.moduleBinaries = true
 
 process {
     withName: APISCRIPTS_GETLINEAGEODBS {
-        ext.args = { "--odb_version odb10 --odb_version odb12 --mode ancestral" }
+        ext.args = { "--odb_version odb10 --odb_version odb12 --taxid 9606 --mode ancestral" }
     }
 }

--- a/modules/sanger-tol/apiscripts/getlineageodbs/tests/basal_and_mammalia.config
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/tests/basal_and_mammalia.config
@@ -2,6 +2,6 @@ nextflow.enable.moduleBinaries = true
 
 process {
     withName: APISCRIPTS_GETLINEAGEODBS {
-        ext.args = { "--odb_version odb10 --taxid 9606 --mode basal" }
+        ext.args = { "--odb_version odb10 --taxid 9606 --mode basal --extra_lineages mammalia" }
     }
 }

--- a/modules/sanger-tol/apiscripts/getlineageodbs/tests/basal_and_mammalia.config
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/tests/basal_and_mammalia.config
@@ -2,6 +2,6 @@ nextflow.enable.moduleBinaries = true
 
 process {
     withName: APISCRIPTS_GETLINEAGEODBS {
-        ext.args = { "--odb_version odb10 --mode basal" }
+        ext.args = { "--odb_version odb10 --taxid 9606 --mode basal" }
     }
 }

--- a/modules/sanger-tol/apiscripts/getlineageodbs/tests/main.nf.test
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/tests/main.nf.test
@@ -49,7 +49,6 @@ nextflow_process {
                 ])
                 input[1] = file(params.fake_odb_path, checkIfExists: true)
                 input[2] = file(params.mapping_dir, checkIfExists: true, type: 'dir')
-                input[3] = "mammalia"
                 """
             }
         }
@@ -95,7 +94,6 @@ nextflow_process {
                 ])
                 input[1] = file(params.fake_odb_path, checkIfExists: true)
                 input[2] = file(params.mapping_dir, checkIfExists: true, type: 'dir')
-                input[3] = []
                 """
             }
         }
@@ -134,7 +132,6 @@ nextflow_process {
                 ])
                 input[1] = file(params.fake_odb_path, checkIfExists: true)
                 input[2] = file(params.mapping_dir, checkIfExists: true, type: 'dir')
-                input[3] = []
                 """
             }
         }

--- a/modules/sanger-tol/apiscripts/getlineageodbs/tests/main.nf.test
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/tests/main.nf.test
@@ -49,8 +49,7 @@ nextflow_process {
                 ])
                 input[1] = file(params.fake_odb_path, checkIfExists: true)
                 input[2] = file(params.mapping_dir, checkIfExists: true, type: 'dir')
-                input[3] = 9606
-                input[4] = "mammalia"
+                input[3] = "mammalia"
                 """
             }
         }
@@ -96,8 +95,7 @@ nextflow_process {
                 ])
                 input[1] = file(params.fake_odb_path, checkIfExists: true)
                 input[2] = file(params.mapping_dir, checkIfExists: true, type: 'dir')
-                input[3] = 9606
-                input[4] = []
+                input[3] = []
                 """
             }
         }
@@ -136,8 +134,7 @@ nextflow_process {
                 ])
                 input[1] = file(params.fake_odb_path, checkIfExists: true)
                 input[2] = file(params.mapping_dir, checkIfExists: true, type: 'dir')
-                input[3] = 9606
-                input[4] = []
+                input[3] = []
                 """
             }
         }

--- a/modules/sanger-tol/apiscripts/getlineageodbs/tests/stub.config
+++ b/modules/sanger-tol/apiscripts/getlineageodbs/tests/stub.config
@@ -2,6 +2,6 @@ nextflow.enable.moduleBinaries = true
 
 process {
     withName: APISCRIPTS_GETLINEAGEODBS {
-        ext.args = { "--odb_version odb10" }
+        ext.args = { "--odb_version odb10 --taxid 9606" }
     }
 }

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/main.nf
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/main.nf
@@ -7,7 +7,6 @@ workflow ODBSEARCH_BUSCO_RESTRUCTURE {
     ch_reference                // tuple([meta], reference)
     val_odb_directory           // val(path to directory containing `lineages` folder)
     val_mapping_directory       // val(path to busco_odb_mapping folder, shipped with APISCRIPTS_GETLINEAGEODBS)
-    ch_taxid                    // tuple([meta], val(9606))
     ch_specified_lineages       // tuple([meta], val("mammalia"))
     val_restructure_busco_dir   // val(boolean)
 
@@ -20,7 +19,6 @@ workflow ODBSEARCH_BUSCO_RESTRUCTURE {
         ch_reference,
         val_odb_directory,
         val_mapping_directory,
-        ch_taxid.map{ meta, taxid -> taxid },
         ch_specified_lineages.map{ meta, lineage -> lineage }
     )
 

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/main.nf
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/main.nf
@@ -21,7 +21,7 @@ workflow ODBSEARCH_BUSCO_RESTRUCTURE {
         val_odb_directory,
         val_mapping_directory,
         ch_taxid.map{ meta, taxid -> taxid },
-        ch_specified_lineages.map{ meta, taxid -> taxid }
+        ch_specified_lineages.map{ meta, lineage -> lineage }
     )
 
 

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/main.nf
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/main.nf
@@ -7,7 +7,6 @@ workflow ODBSEARCH_BUSCO_RESTRUCTURE {
     ch_reference                // tuple([meta], reference)
     val_odb_directory           // val(path to directory containing `lineages` folder)
     val_mapping_directory       // val(path to busco_odb_mapping folder, shipped with APISCRIPTS_GETLINEAGEODBS)
-    ch_specified_lineages       // tuple([meta], val("mammalia"))
     val_restructure_busco_dir   // val(boolean)
 
     main:
@@ -19,7 +18,6 @@ workflow ODBSEARCH_BUSCO_RESTRUCTURE {
         ch_reference,
         val_odb_directory,
         val_mapping_directory,
-        ch_specified_lineages.map{ meta, lineage -> lineage }
     )
 
 

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/meta.yml
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/meta.yml
@@ -24,9 +24,6 @@ input:
       type: string
       description: |
         Path to busco_odb_mapping folder, shipped with APISCRIPTS_GETLINEAGEODBS
-  - val_taxid:
-      type: number
-      description: Taxid of the input species
   - val_specified_lineages:
       type: string
       description: |

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/meta.yml
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/meta.yml
@@ -24,10 +24,6 @@ input:
       type: string
       description: |
         Path to busco_odb_mapping folder, shipped with APISCRIPTS_GETLINEAGEODBS
-  - val_specified_lineages:
-      type: string
-      description: |
-        A CSV string of additional lineages to run busco with
   - val_output_dir:
       type: string
       description: Output directory for the restructure busco directory

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/tests/main.nf.test
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/tests/main.nf.test
@@ -68,9 +68,8 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = file(params.odb_path, checkIfExists: true, type: 'dir')
                 input[2] = file(params.mapping_path, checkIfExists: true, type: 'dir')
-                input[3] = channel.of([ [ id: "ignored" ], "5630" ])
-                input[4] = channel.of([ [ id: "also_ignored" ], [] ])
-                input[5] = channel.of(true)
+                input[3] = channel.of([ [ id: "also_ignored" ], [] ])
+                input[4] = channel.of(true)
                 """
             }
         }

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/tests/main.nf.test
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/tests/main.nf.test
@@ -68,8 +68,7 @@ nextflow_workflow {
                 input[0] = GUNZIP.out.gunzip
                 input[1] = file(params.odb_path, checkIfExists: true, type: 'dir')
                 input[2] = file(params.mapping_path, checkIfExists: true, type: 'dir')
-                input[3] = channel.of([ [ id: "also_ignored" ], [] ])
-                input[4] = channel.of(true)
+                input[3] = channel.of(true)
                 """
             }
         }

--- a/subworkflows/sanger-tol/odbsearch_busco_restructure/tests/offline_basal.config
+++ b/subworkflows/sanger-tol/odbsearch_busco_restructure/tests/offline_basal.config
@@ -8,7 +8,7 @@ process {
     }
 
     withName: APISCRIPTS_GETLINEAGEODBS {
-        ext.args = { "--odb_version odb10 --extra_lineages lepidoptera --print_output" }
+        ext.args = { "--odb_version odb10 --taxid 5630 --extra_lineages lepidoptera --print_output" }
     }
 
 }


### PR DESCRIPTION
As I'm reviewing https://github.com/sanger-tol/busco/pull/39 I found a couple of things to change in the shared module and sub-workflow.

The most important is to make `--taxid` optional in `get_odbs.py` and its module/sub-workflow. Indeed it's only needed in "ancestral" and "latest" modes. The module/sub-workflow are happy as long as they get a list of lineage names, and they don't really care about the taxon ID thereafter.

At that point I realised we were in fact not following the nf-core guideline on required `val` inputs: https://nf-co.re/docs/specifications/components/modules/input-output-options#required-val-channel-inputs
and I went on and _removed_ `taxid` and `specified_lineages` channels to pass values via `ext.args` instead. The funny thing is that the sub-workflow test was _already_ ignoring the `specified_lineages` channel and passing a value via `ext.args` !

https://github.com/sanger-tol/busco/pull/40 is where I apply these changes to the pipeline.

<!--
# sanger-tol/nf-core-modules pull request

Many thanks for contributing to sanger-tol/nf-core-modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/sanger-tol/nf-core-modules/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] If you've added or modified a sub-workflow, ensure all sub-analyses are emitted as individual channels. Outputs may also be collected together by analysis type or input sample, for instance to support downstream analysis or publishing.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
